### PR TITLE
Initial Carbon Estimation method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "editor.tabSize": 2
 }

--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -26,19 +26,19 @@
       <div class="grid grid-cols-2 grid-flow-row gap-4">
         @if (carbonEstimation().upstreamEmissions) {
           <span class="text-2xl font-bold text-[#40798C]">Upstream Emissions:</span>
-          <span class="text-2xl">{{ carbonEstimation().upstreamEmissions }}</span>
+          <span class="text-2xl">{{ carbonEstimation().upstreamEmissions | number: '1.0-2' }}%</span>
         }
         @if (carbonEstimation().cloudEmissions) {
           <span class="text-2xl font-bold text-[#CB3775]">Cloud Emissions:</span>
-          <span class="text-2xl">{{ carbonEstimation().cloudEmissions }}</span>
+          <span class="text-2xl">{{ carbonEstimation().cloudEmissions | number: '1.0-2' }}%</span>
         }
         @if (carbonEstimation().directEmissions) {
           <span class="text-2xl font-bold text-[#91234C]">Direct Emissions:</span>
-          <span class="text-2xl">{{ carbonEstimation().directEmissions }}</span>
+          <span class="text-2xl">{{ carbonEstimation().directEmissions | number: '1.0-2' }}%</span>
         }
         @if (carbonEstimation().downstreamEmissions) {
           <span class="text-2xl font-bold text-[#4B7E56]">Downstream Emissions:</span>
-          <span class="text-2xl">{{ carbonEstimation().downstreamEmissions }}</span>
+          <span class="text-2xl">{{ carbonEstimation().downstreamEmissions | number: '1.0-2' }}%</span>
         }
       </div>
     </div>

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, input } from '@angular/core';
 import { CarbonEstimation } from '../carbon-estimator';
+import { DecimalPipe } from '@angular/common';
 
 @Component({
   selector: 'sl-carbon-estimation',
   standalone: true,
-  imports: [],
+  imports: [DecimalPipe],
   templateUrl: './carbon-estimation.component.html',
 })
 export class CarbonEstimationComponent implements OnInit {
@@ -19,17 +20,9 @@ export class CarbonEstimationComponent implements OnInit {
 
   ngOnInit() {
     const carbonEstimation = this.carbonEstimation();
-    const total =
-      (carbonEstimation.upstreamEmissions ?? 0) +
-      (carbonEstimation.cloudEmissions ?? 0) +
-      (carbonEstimation.directEmissions ?? 0) +
-      (carbonEstimation.downstreamEmissions ?? 0);
-    this.upstreamEmissionsHeight =
-      carbonEstimation.upstreamEmissions ? (carbonEstimation.upstreamEmissions / total) * 400 : 0;
-    this.cloudEmissionsHeight = carbonEstimation.cloudEmissions ? (carbonEstimation.cloudEmissions / total) * 400 : 0;
-    this.directEmissionsHeight =
-      carbonEstimation.directEmissions ? (carbonEstimation.directEmissions / total) * 400 : 0;
-    this.downstreamEmissionsHeight =
-      carbonEstimation.downstreamEmissions ? (carbonEstimation.downstreamEmissions / total) * 400 : 0;
+    this.upstreamEmissionsHeight = carbonEstimation.upstreamEmissions * 4;
+    this.cloudEmissionsHeight = carbonEstimation.cloudEmissions * 4;
+    this.directEmissionsHeight = carbonEstimation.directEmissions * 4;
+    this.downstreamEmissionsHeight = carbonEstimation.downstreamEmissions * 4;
   }
 }

--- a/src/app/carbon-estimator.d.ts
+++ b/src/app/carbon-estimator.d.ts
@@ -1,8 +1,9 @@
 export type CarbonEstimation = {
-  upstreamEmissions?: number;
-  cloudEmissions?: number;
-  directEmissions?: number;
-  downstreamEmissions?: number;
+  version: string;
+  upstreamEmissions: number;
+  cloudEmissions: number;
+  directEmissions: number;
+  downstreamEmissions: number;
 };
 
 export type EstimatorValues = {

--- a/src/app/carbon-estimator/carbon-estimator.component.ts
+++ b/src/app/carbon-estimator/carbon-estimator.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CarbonEstimatorFormComponent } from '../carbon-estimator-form/carbon-estimator-form.component';
 import { CarbonEstimationComponent } from '../carbon-estimation/carbon-estimation.component';
 import { CarbonEstimation, EstimatorValues } from '../carbon-estimator';
+import { CarbonEstimationService } from '../services/carbon-estimation.service';
 
 @Component({
   selector: 'sl-carbon-estimator',
@@ -14,22 +15,15 @@ export class CarbonEstimatorComponent {
   public formValue: EstimatorValues | undefined;
   public carbonEstimation: CarbonEstimation = {} as CarbonEstimation;
 
+  constructor(private estimationService: CarbonEstimationService) {}
+
   public handleFormSubmit(formValue: EstimatorValues) {
     this.formValue = formValue;
-    this.carbonEstimation = this.calculateCarbonEstimation(this.formValue);
+    this.carbonEstimation = this.estimationService.calculateCarbonEstimation(this.formValue);
     this.view = 'calculation';
   }
 
   public handleBack() {
     this.view = 'form';
-  }
-
-  private calculateCarbonEstimation(formValue: EstimatorValues): CarbonEstimation {
-    return {
-      upstreamEmissions: formValue.upstream ? Math.random() : undefined,
-      cloudEmissions: formValue.cloud ? Math.random() : undefined,
-      directEmissions: formValue.onPrem ? Math.random() : undefined,
-      downstreamEmissions: formValue.downstream ? Math.random() : undefined,
-    };
   }
 }

--- a/src/app/estimation/device-type.spec.ts
+++ b/src/app/estimation/device-type.spec.ts
@@ -1,0 +1,57 @@
+import { laptop, desktop, server, network } from './device-type';
+
+describe('Device type of laptop', () => {
+  it('Calculates kWh of 1 laptop', () => {
+    expect(laptop.estimateYearlyEnergy(1)).toBeCloseTo(31.28);
+  });
+
+  it('Calculates kWh of 30 laptops', () => {
+    expect(laptop.estimateYearlyEnergy(30)).toBeCloseTo(938.4);
+  });
+
+  it('Calculates upstream emissions from direct', () => {
+    expect(laptop.estimateYearlyUpstreamEmissions(20)).toBe(80);
+  });
+});
+
+describe('Device type of desktop', () => {
+  it('Calculates kWh of 1 desktop', () => {
+    expect(desktop.estimateYearlyEnergy(1)).toBeCloseTo(132.48);
+  });
+
+  it('Calculates kWh of 30 desktops', () => {
+    expect(desktop.estimateYearlyEnergy(30)).toBeCloseTo(3974.4);
+  });
+
+  it('Calculates upstream emissions from direct', () => {
+    expect(desktop.estimateYearlyUpstreamEmissions(20)).toBe(20);
+  });
+});
+
+describe('Device type of server', () => {
+  it('Calculates kWh of 1 server', () => {
+    expect(server.estimateYearlyEnergy(1)).toBeCloseTo(3504);
+  });
+
+  it('Calculates kWh of 30 servers', () => {
+    expect(server.estimateYearlyEnergy(30)).toBeCloseTo(105120);
+  });
+
+  it('Calculates upstream emissions from direct', () => {
+    expect(server.estimateYearlyUpstreamEmissions(80)).toBe(20);
+  });
+});
+
+describe('Device type of network', () => {
+  it('Calculates kWh of 1 network device', () => {
+    expect(network.estimateYearlyEnergy(1)).toBeCloseTo(1314);
+  });
+
+  it('Calculates kWh of 30 desktops', () => {
+    expect(network.estimateYearlyEnergy(30)).toBeCloseTo(39420);
+  });
+
+  it('Calculates upstream emissions from direct', () => {
+    expect(network.estimateYearlyUpstreamEmissions(80)).toBe(20);
+  });
+});

--- a/src/app/estimation/device-type.ts
+++ b/src/app/estimation/device-type.ts
@@ -1,0 +1,23 @@
+import { Hour, KgCo2e, KilowattHour, Watt } from '../types/units';
+
+class DeviceType {
+  constructor(
+    private averagePower: Watt,
+    private averageYearlyUsage: Hour,
+    private embodiedCarbonRatio: number
+  ) {}
+
+  estimateYearlyEnergy(deviceCount: number): KilowattHour {
+    return (deviceCount * this.averageYearlyUsage * this.averagePower) / 1000;
+  }
+
+  estimateYearlyUpstreamEmissions(yearlyDirectEmissions: KgCo2e): KgCo2e {
+    return this.embodiedCarbonRatio * yearlyDirectEmissions;
+  }
+}
+
+// Sources for device power figures are listed on https://www.techcarbonstandard.org/, rounded to nearest watt
+export const laptop = new DeviceType(17, 8 * 230, 80 / 20);
+export const desktop = new DeviceType(72, 8 * 230, 50 / 50);
+export const server = new DeviceType(400, 24 * 365, 20 / 80);
+export const network = new DeviceType(150, 24 * 365, 20 / 80);

--- a/src/app/estimation/estimate-cloud-emissions.ts
+++ b/src/app/estimation/estimate-cloud-emissions.ts
@@ -1,0 +1,28 @@
+import { MonthlyCloudBill, Location } from '../carbon-estimator';
+import { server } from './device-type';
+import { estimateEnergyEmissions } from './estimate-energy-emissions';
+import { KgCo2e, KilowattHour } from '../types/units';
+
+// Calculated in spreadsheet, need some link to explanation
+const COST_TO_KWH_RATIO = 0.156;
+const AVERAGE_PUE = 1.18;
+
+export function estimateCloudEmissions(cloudPercentage: number, monthlyCloudBill: MonthlyCloudBill, cloudLocation: Location): KgCo2e {
+  const cloudEnergy = estimateCloudEnergy(cloudPercentage, monthlyCloudBill);
+  const cloudDirectEmissions = estimateEnergyEmissions(cloudEnergy, cloudLocation);
+  const cloudUpstreamEmissions = server.estimateYearlyUpstreamEmissions(cloudDirectEmissions);
+  const totalCloudEmissions = cloudDirectEmissions + cloudUpstreamEmissions;
+  return totalCloudEmissions;
+}
+
+function estimateCloudEnergy(cloudPercentage: number, monthlyCloudBill: MonthlyCloudBill): KilowattHour {
+  if (cloudPercentage === 0) {
+    return 0;
+  }
+
+  const range = monthlyCloudBill.split('-');
+  const midpoint = (Number(range[0]) + Number(range[1])) / 2;
+
+  return midpoint * COST_TO_KWH_RATIO * AVERAGE_PUE;
+}
+

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -1,0 +1,55 @@
+import { PurposeOfSite, Location } from '../carbon-estimator';
+import { estimateEnergyEmissions as estimateEnergyEmissions } from './estimate-energy-emissions';
+import { Gb, Hour, KilowattHour } from '../types/units';
+
+interface SiteInformation {
+  averageMonthlyUserTime: Hour,
+  averageMonthlyUserData: Gb,
+}
+
+// See https://sustainablewebdesign.org/calculating-digital-emissions/
+// TODO - Split this into network by GB and end user by time
+const DOWNSTREAM_GB_TO_KWH_RATIO = 0.5346;
+
+const siteTypeInfo: Record<PurposeOfSite, SiteInformation> = {
+  information: {
+    averageMonthlyUserTime: 0.016,
+    averageMonthlyUserData: 0.000781
+  },
+  eCommerce: {
+    averageMonthlyUserTime: 0.1,
+    averageMonthlyUserData: 0.01656
+  },
+  socialMedia: {
+    averageMonthlyUserTime: 16.3,
+    averageMonthlyUserData: 4.4443
+  },
+  streaming: {
+    averageMonthlyUserTime: 22.1429,
+    averageMonthlyUserData: 10.3912
+  },
+  average: {
+    averageMonthlyUserTime: 9.648,
+    averageMonthlyUserData: 3.713
+  }
+}
+
+export function estimateDownstreamEmissions(monthlyActiveUsers: number, purposeOfSite: PurposeOfSite, customerLocation: Location) {
+  const downstreamDataTransfer = estimateDownstreamDataTransfer(monthlyActiveUsers, purposeOfSite);
+  const downstreamEnergy = estimateDownstreamEnergy(downstreamDataTransfer);
+  const downstreamEmissions = estimateEnergyEmissions(downstreamEnergy, customerLocation);
+  return downstreamEmissions;
+}
+
+function estimateDownstreamDataTransfer(monthlyActiveUsers: number, purposeOfSite: PurposeOfSite): Gb {
+  if (monthlyActiveUsers === 0) {
+    return 0;
+  }
+
+  return siteTypeInfo[purposeOfSite].averageMonthlyUserData * monthlyActiveUsers * 12;
+}
+
+function estimateDownstreamEnergy(dataTransferred: Gb): KilowattHour {
+  return dataTransferred * DOWNSTREAM_GB_TO_KWH_RATIO;
+}
+

--- a/src/app/estimation/estimate-energy-emissions.spec.ts
+++ b/src/app/estimation/estimate-energy-emissions.spec.ts
@@ -1,0 +1,19 @@
+import { estimateEnergyEmissions } from './estimate-energy-emissions';
+
+describe('Estimate Direct emissions', () => {
+  it('Should estimate emissions using global average', () => {
+    expect(estimateEnergyEmissions(1, 'global')).toBeCloseTo(0.494);
+  });
+
+  it('Should estimate emissions using us average', () => {
+    expect(estimateEnergyEmissions(1, 'us')).toBeCloseTo(0.41);
+  });
+
+  it('Should estimate emissions using eu average', () => {
+    expect(estimateEnergyEmissions(1, 'eu')).toBeCloseTo(0.33);
+  });
+
+  it('Should estimate emissions using uk average', () => {
+    expect(estimateEnergyEmissions(1, 'uk')).toBeCloseTo(0.238);
+  });
+});

--- a/src/app/estimation/estimate-energy-emissions.ts
+++ b/src/app/estimation/estimate-energy-emissions.ts
@@ -1,0 +1,17 @@
+import { KgCo2e, KgCo2ePerKwh, KilowattHour } from '../types/units';
+import { Location } from '../carbon-estimator'
+
+// Carbon Intensity figures sourced from https://ember-climate.org/data/data-tools/data-explorer/
+const location_intensity_map: Record<Location, KgCo2ePerKwh> = {
+  global: 0.494,
+  us: 0.41,
+  eu: 0.33,
+  uk: 0.238,
+};
+
+export function estimateEnergyEmissions(
+  energy: KilowattHour,
+  location: Location
+): KgCo2e {
+  return location_intensity_map[location] * energy;
+}

--- a/src/app/services/carbon-estimation.service.spec.ts
+++ b/src/app/services/carbon-estimation.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CarbonEstimationService } from './carbon-estimation.service';
+import { CarbonEstimation } from '../carbon-estimator';
+
+function checkTotalPercentage(estimation: CarbonEstimation) {
+  expect(estimation.upstreamEmissions).toBeGreaterThanOrEqual(0);
+  expect(estimation.directEmissions).toBeGreaterThanOrEqual(0);
+  expect(estimation.cloudEmissions).toBeGreaterThanOrEqual(0);
+  expect(estimation.downstreamEmissions).toBeGreaterThanOrEqual(0);
+  const total = estimation.upstreamEmissions + estimation.directEmissions + estimation.cloudEmissions + estimation.downstreamEmissions;
+  expect(total).toBeCloseTo(100);
+}
+
+describe('CarbonEstimationService', () => {
+  let service: CarbonEstimationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CarbonEstimationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should include version and zeroed values in estimation', () => {
+    const estimation = service.calculateCarbonEstimation({})
+    expect(estimation.version).toBe('0.0.1');
+    expect(estimation.upstreamEmissions).toBe(0);
+    expect(estimation.directEmissions).toBe(0);
+    expect(estimation.cloudEmissions).toBe(0);
+    expect(estimation.downstreamEmissions).toBe(0);
+  });
+
+  it('should calculate estimations as percentages', () => {
+    const estimation = service.calculateCarbonEstimation({
+      upstream: {
+        headCount:1,
+        desktopToLaptopPercentage: 0,
+      }
+    });
+    checkTotalPercentage(estimation);
+  });
+
+  it('should deal with NaN for server count', () => {
+    const estimation = service.calculateCarbonEstimation({
+      upstream: {
+        headCount:1,
+        desktopToLaptopPercentage: 0,
+      },
+      onPrem: {
+        location: 'global',
+        numberOfServers: NaN,
+      }
+    });
+    checkTotalPercentage(estimation);
+  });
+});

--- a/src/app/services/carbon-estimation.service.ts
+++ b/src/app/services/carbon-estimation.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+import { CarbonEstimation } from '../carbon-estimator';
+import { desktop, laptop, network, server } from '../estimation/device-type';
+import { estimateEnergyEmissions as estimateEnergyEmissions } from '../estimation/estimate-energy-emissions';
+import { estimateCloudEmissions } from '../estimation/estimate-cloud-emissions';
+import { estimateDownstreamEmissions } from '../estimation/estimate-downstream-emissions';
+import { EstimatorValues } from '../carbon-estimator';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CarbonEstimationService {
+  constructor() {}
+
+  calculateCarbonEstimation(formValue: EstimatorValues): CarbonEstimation {
+    // TODO - these should be required params
+    const desktopPercent = formValue.upstream?.desktopToLaptopPercentage ?? 0;
+    const headCount = formValue.upstream?.headCount ?? 0;
+    const cloudPercentage = formValue.cloud?.cloudPercentage ?? 0;
+    const monthlyCloudBill = formValue.cloud?.monthlyCloudBill ?? '0-200';
+    const onPremLocation = formValue.onPrem?.location ?? 'global';
+    const cloudLocation = formValue.cloud?.location ?? 'global';
+    const customerLocation = formValue.downstream?.customerLocation ?? 'global';
+    const monthlyActiveUsers = formValue.downstream?.monthlyActiveUsers ?? 0;
+    const purposeOfSite = formValue.downstream?.purposeOfSite ?? 'average';
+
+    const laptopPercent = 100 - desktopPercent;
+
+    const desktopCount = calculateCeilingPercentage(desktopPercent, headCount);
+    const laptopCount = calculateCeilingPercentage(laptopPercent, headCount);
+    const serverCount = estimateServerCount(cloudPercentage, headCount, formValue.onPrem?.numberOfServers);
+    const networkCount = estimateNetworkDeviceCount(desktopCount, serverCount);
+
+    const desktopEnergy = desktop.estimateYearlyEnergy(desktopCount);
+    const laptopEnergy = laptop.estimateYearlyEnergy(laptopCount);
+    const serverEnergy = server.estimateYearlyEnergy(serverCount);
+    const networkEnergy = network.estimateYearlyEnergy(networkCount);
+
+    const desktopDirectEmissions = estimateEnergyEmissions(desktopEnergy, onPremLocation);
+    const laptopDirectEmissions = estimateEnergyEmissions(laptopEnergy, onPremLocation);
+    const serverDirectEmissions = estimateEnergyEmissions(serverEnergy, onPremLocation);
+    const networkDirectEmissions = estimateEnergyEmissions(networkEnergy, onPremLocation);
+
+    const totalDirectEmissions = desktopDirectEmissions + laptopDirectEmissions + serverDirectEmissions + networkDirectEmissions;
+
+    const desktopUpstreamEmissions = desktop.estimateYearlyUpstreamEmissions(desktopDirectEmissions);
+    const laptopUpstreamEmissions = laptop.estimateYearlyUpstreamEmissions(laptopDirectEmissions);
+    const serverUpstreamEmissions = server.estimateYearlyUpstreamEmissions(serverDirectEmissions);
+    const networkUpstreamEmissions = network.estimateYearlyUpstreamEmissions(networkDirectEmissions);
+
+    const totalUpstreamEmissions = desktopUpstreamEmissions + laptopUpstreamEmissions + serverUpstreamEmissions + networkUpstreamEmissions;
+
+    const cloudEmissions = estimateCloudEmissions(cloudPercentage, monthlyCloudBill, cloudLocation);
+
+    const downstreamEmissions = estimateDownstreamEmissions(monthlyActiveUsers, purposeOfSite, customerLocation);
+
+    return toPercentages({
+      version: '0.0.1',
+      upstreamEmissions: totalUpstreamEmissions,
+      cloudEmissions: cloudEmissions,
+      directEmissions: totalDirectEmissions,
+      downstreamEmissions: downstreamEmissions
+    })
+  }
+}
+
+function toPercentages(input: CarbonEstimation): CarbonEstimation {
+  const total = input.upstreamEmissions + input.directEmissions + input.cloudEmissions + input.downstreamEmissions;
+  if (total === 0) {
+    return input;
+  }
+  const percentRatio = 100 / total;
+  return {
+    ...input,
+    upstreamEmissions: input.upstreamEmissions * percentRatio,
+    directEmissions: input.directEmissions * percentRatio,
+    cloudEmissions: input.cloudEmissions * percentRatio,
+    downstreamEmissions: input.downstreamEmissions * percentRatio,
+  }
+}
+
+function calculateCeilingPercentage(percentage: number, value: number) {
+  return Math.ceil((percentage / 100) * value);
+}
+
+function estimateServerCount(cloudPercentage: number, headCount: number, inputServerCount: number | undefined): number {
+  if (inputServerCount) {
+    return inputServerCount;
+  }
+  return calculateCeilingPercentage(100 - cloudPercentage, headCount * 0.1);
+}
+
+function estimateNetworkDeviceCount(desktopCount: number, serverCount: number) {
+  return Math.ceil((desktopCount + serverCount)/2);
+}

--- a/src/app/types/units.ts
+++ b/src/app/types/units.ts
@@ -1,0 +1,6 @@
+export type Watt = number;
+export type Hour = number;
+export type KilowattHour = number;
+export type KgCo2ePerKwh = number;
+export type KgCo2e = number;
+export type Gb = number;


### PR DESCRIPTION
First pass at estimation method:
- Type alias' for numeric output - helps in documentation but at present can still use any number
- Desktop/Laptop count split based on headcount
- If number of servers not specified, assume 10% of headcount with sliding cloud scale
- Network device count 50% of fixed location devices
- Average Power for device types to calculate energy
- Location used to estimate CO2e via Carbon Intensity
- Ratio of device carbon applied to estimate embodied carbon
- Cloud costs apply ratio to estimate kWh
- Downstream estimated via network transfer averages and SWD method
- Results given as percentages and UI updated to display to 2dp