### PR TITLE
Rename Location type so that it doesn't cause confusion

### DIFF
--- a/src/app/carbon-estimator.d.ts
+++ b/src/app/carbon-estimator.d.ts
@@ -23,18 +23,18 @@ export type EstimatorFormValues = {
   }>;
   onPrem: FormGroup<{
     enabled: FormControl<boolean>;
-    location: FormControl<Location>;
+    location: FormControl<WorldLocation>;
     numberOfServers: FormControl<number>;
   }>;
   cloud: FormGroup<{
     enabled: FormControl<boolean>;
-    location: FormControl<Location>;
+    location: FormControl<WorldLocation>;
     cloudPercentage: FormControl<number>;
     monthlyCloudBill: FormControl<MonthlyCloudBill>;
   }>;
   downstream: FormGroup<{
     enabled: FormControl<boolean>;
-    customerLocation: FormControl<Location>;
+    customerLocation: FormControl<WorldLocation>;
     monthlyActiveUsers: FormControl<number>;
     mobilePercentage: FormControl<number>;
     purposeOfSite: FormControl<PurposeOfSite>;
@@ -44,7 +44,7 @@ export type EstimatorFormValues = {
 type FormSection<T> = T & { enabled: boolean };
 
 export type OnPrem = {
-  location: Location;
+  location: WorldLocation;
   numberOfServers: number;
 };
 export type Upstream = {
@@ -52,19 +52,19 @@ export type Upstream = {
   desktopToLaptopPercentage: number;
 };
 export type Cloud = {
-  location: Location;
+  location: WorldLocation;
   cloudPercentage: number;
   monthlyCloudBill: MonthlyCloudBill;
 };
 export type Downstream = {
-  customerLocation: Location;
+  customerLocation: WorldLocation;
   monthlyActiveUsers: number;
   mobilePercentage: number;
   purposeOfSite: PurposeOfSite;
 };
 
 export const locationArray = ['global', 'uk', 'eu', 'us'] as const;
-export type Location = (typeof locationArray)[number];
+export type WorldLocation = (typeof locationArray)[number];
 
 export const monthlyCloudBillArray = [
   '0-200',

--- a/src/app/estimation/estimate-cloud-emissions.ts
+++ b/src/app/estimation/estimate-cloud-emissions.ts
@@ -1,4 +1,4 @@
-import { MonthlyCloudBill, Location } from '../carbon-estimator';
+import { MonthlyCloudBill, WorldLocation } from '../carbon-estimator';
 import { server } from './device-type';
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
 import { KgCo2e, KilowattHour } from '../types/units';
@@ -10,7 +10,7 @@ const AVERAGE_PUE = 1.18;
 export function estimateCloudEmissions(
   cloudPercentage: number,
   monthlyCloudBill: MonthlyCloudBill,
-  cloudLocation: Location
+  cloudLocation: WorldLocation
 ): KgCo2e {
   const cloudEnergy = estimateCloudEnergy(cloudPercentage, monthlyCloudBill);
   const cloudDirectEmissions = estimateEnergyEmissions(cloudEnergy, cloudLocation);

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -1,4 +1,4 @@
-import { PurposeOfSite, Location } from '../carbon-estimator';
+import { PurposeOfSite, WorldLocation } from '../carbon-estimator';
 import { estimateEnergyEmissions as estimateEnergyEmissions } from './estimate-energy-emissions';
 import { Gb, Hour, KilowattHour } from '../types/units';
 
@@ -37,7 +37,7 @@ const siteTypeInfo: Record<PurposeOfSite, SiteInformation> = {
 export function estimateDownstreamEmissions(
   monthlyActiveUsers: number,
   purposeOfSite: PurposeOfSite,
-  customerLocation: Location
+  customerLocation: WorldLocation
 ) {
   const downstreamDataTransfer = estimateDownstreamDataTransfer(monthlyActiveUsers, purposeOfSite);
   const downstreamEnergy = estimateDownstreamEnergy(downstreamDataTransfer);

--- a/src/app/estimation/estimate-energy-emissions.ts
+++ b/src/app/estimation/estimate-energy-emissions.ts
@@ -1,14 +1,14 @@
 import { KgCo2e, KgCo2ePerKwh, KilowattHour } from '../types/units';
-import { Location } from '../carbon-estimator';
+import { WorldLocation } from '../carbon-estimator';
 
 // Carbon Intensity figures sourced from https://ember-climate.org/data/data-tools/data-explorer/
-const location_intensity_map: Record<Location, KgCo2ePerKwh> = {
+const location_intensity_map: Record<WorldLocation, KgCo2ePerKwh> = {
   global: 0.494,
   us: 0.41,
   eu: 0.33,
   uk: 0.238,
 };
 
-export function estimateEnergyEmissions(energy: KilowattHour, location: Location): KgCo2e {
+export function estimateEnergyEmissions(energy: KilowattHour, location: WorldLocation): KgCo2e {
   return location_intensity_map[location] * energy;
 }


### PR DESCRIPTION
Had a few confusing errors while trying to refactor functions passing the location and realised that this was due to the IDE/typescript assuming this meant the [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location) interface.