### PR TITLE
Update CO2.js to make use of newly added types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@material-design-icons/font": "^0.14.13",
         "@ncstate/sat-popover": "^11.0.0",
         "@tgwf/co2": "^0.14.3",
-        "@types/tgwf__co2": "^0.14.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -37,6 +36,7 @@
         "@angular/compiler-cli": "^17.2.0",
         "@tailwindcss/forms": "^0.5.7",
         "@types/jasmine": "~5.1.0",
+        "@types/tgwf__co2": "^0.14.2",
         "@typescript-eslint/eslint-plugin": "6.19.0",
         "@typescript-eslint/parser": "6.19.0",
         "@web/test-runner": "^0.18.0",
@@ -4571,9 +4571,10 @@
       }
     },
     "node_modules/@types/tgwf__co2": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@types/tgwf__co2/-/tgwf__co2-0.14.1.tgz",
-      "integrity": "sha512-q+j3WgYeg+bOZhS5iAKHxFvqOsXi00f001YGHsW6Tr2LacSw7Zkr+3+Gpj8pZyC/YJ6QiZqSlM0I/BFhfXUELw=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@types/tgwf__co2/-/tgwf__co2-0.14.2.tgz",
+      "integrity": "sha512-kgSh14wLbydB4TwHYVq/1pbOC4ww3EDNgLQ3kZSH6wZyDmBMTRyEaIBqXtCmuhKCotU71QAOpkIO3IHbHTtANA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@material-design-icons/font": "^0.14.13",
     "@ncstate/sat-popover": "^11.0.0",
     "@tgwf/co2": "^0.14.3",
-    "@types/tgwf__co2": "^0.14.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
@@ -40,6 +39,7 @@
     "@angular/compiler-cli": "^17.2.0",
     "@tailwindcss/forms": "^0.5.7",
     "@types/jasmine": "~5.1.0",
+    "@types/tgwf__co2": "^0.14.2",
     "@typescript-eslint/eslint-plugin": "6.19.0",
     "@typescript-eslint/parser": "6.19.0",
     "@web/test-runner": "^0.18.0",

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -9,14 +9,6 @@ interface SiteInformation {
   averageMonthlyUserData: Gb;
 }
 
-interface CO2EstimateComponents {
-  consumerDeviceCO2: number;
-  networkCO2: number;
-  dataCenterCO2: number;
-  productionCO2: number;
-  total: number;
-}
-
 const BYTES_IN_GIGABYTE = 1000 * 1000 * 1000;
 
 // Needs source from our own research
@@ -92,6 +84,8 @@ function estimateNetworkEmissions(downstream: Downstream, downstreamDataTransfer
     },
   };
   const result = co2Inst.perByteTrace(downstreamDataTransfer * BYTES_IN_GIGABYTE, false, options);
-  // Force a cast to type we know is returned when segment option is used
-  return (result.co2 as unknown as CO2EstimateComponents).networkCO2 / 1000;
+  if (typeof result.co2 !== 'number') {
+    return result.co2.networkCO2 / 1000;
+  }
+  throw new Error('perByteTrace should return CO2EstimateComponents for segment results');
 }


### PR DESCRIPTION
Also moved types into dev dependencies

The error should never be thrown but I don't know of a nicer way in typescript to say 'just trust me, it will always return this'