### PR TITLE
Split emission categories into their component parts

### DIFF
--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -7,17 +7,17 @@
         x="0"
         [attr.y]="upstreamEmissionsHeight"
         width="100"
-        [attr.height]="cloudEmissionsHeight"
+        [attr.height]="indirectEmissionsHeight"
         style="fill: rgb(203 55 117)" />
       <rect
         x="0"
-        [attr.y]="upstreamEmissionsHeight + cloudEmissionsHeight"
+        [attr.y]="upstreamEmissionsHeight + indirectEmissionsHeight"
         width="100"
         [attr.height]="directEmissionsHeight"
         style="fill: rgb(145 35 76)" />
       <rect
         x="0"
-        [attr.y]="upstreamEmissionsHeight + cloudEmissionsHeight + directEmissionsHeight"
+        [attr.y]="upstreamEmissionsHeight + indirectEmissionsHeight + directEmissionsHeight"
         width="100"
         [attr.height]="downstreamEmissionsHeight"
         style="fill: rgb(75 126 86)" />
@@ -25,19 +25,19 @@
     <div class="grid grid-cols-[1fr_6rem] grid-flow-row gap-4">
       @if (carbonEstimation().upstreamEmissions) {
         <span class="text-lg text-[#40798C]">Upstream Emissions:</span>
-        <span class="text-lg">{{ carbonEstimation().upstreamEmissions | number: '1.0-2' }}%</span>
+        <span class="text-lg">{{ upstreamEmissionsPercent | number: '1.0-0' }}%</span>
       }
-      @if (carbonEstimation().cloudEmissions) {
-        <span class="text-lg text-[#CB3775]">Cloud Emissions:</span>
-        <span class="text-lg">{{ carbonEstimation().cloudEmissions | number: '1.0-2' }}%</span>
+      @if (carbonEstimation().indirectEmissions) {
+        <span class="text-lg text-[#CB3775]">Indirect Emissions:</span>
+        <span class="text-lg">{{ indirectEmissionsPercent | number: '1.0-0' }}%</span>
       }
       @if (carbonEstimation().directEmissions) {
         <span class="text-lg text-[#91234C]">Direct Emissions:</span>
-        <span class="text-lg">{{ carbonEstimation().directEmissions | number: '1.0-2' }}%</span>
+        <span class="text-lg">{{ directEmissionsPercent | number: '1.0-0' }}%</span>
       }
       @if (carbonEstimation().downstreamEmissions) {
         <span class="text-lg text-[#4B7E56]">Downstream Emissions:</span>
-        <span class="text-lg">{{ carbonEstimation().downstreamEmissions | number: '1.0-2' }}%</span>
+        <span class="text-lg">{{ downstreamEmissionsPercent | number: '1.0-0' }}%</span>
       }
     </div>
   </div>

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -1,6 +1,7 @@
 import { Component, effect, input } from '@angular/core';
 import { CarbonEstimation } from '../carbon-estimator';
 import { DecimalPipe } from '@angular/common';
+import { sumValues } from '../utils/number-object';
 
 @Component({
   selector: 'sl-carbon-estimation',
@@ -11,18 +12,28 @@ import { DecimalPipe } from '@angular/common';
 export class CarbonEstimationComponent {
   public carbonEstimation = input.required<CarbonEstimation>();
 
+  public upstreamEmissionsPercent: number = 0;
+  public indirectEmissionsPercent: number = 0;
+  public directEmissionsPercent: number = 0;
+  public downstreamEmissionsPercent: number = 0;
+
   public upstreamEmissionsHeight: number = 0;
-  public cloudEmissionsHeight: number = 0;
+  public indirectEmissionsHeight: number = 0;
   public directEmissionsHeight: number = 0;
   public downstreamEmissionsHeight: number = 0;
 
   constructor() {
     effect(() => {
       const carbonEstimation = this.carbonEstimation();
-      this.upstreamEmissionsHeight = carbonEstimation.upstreamEmissions * 4;
-      this.cloudEmissionsHeight = carbonEstimation.cloudEmissions * 4;
-      this.directEmissionsHeight = carbonEstimation.directEmissions * 4;
-      this.downstreamEmissionsHeight = carbonEstimation.downstreamEmissions * 4;
+      this.upstreamEmissionsPercent = sumValues(carbonEstimation.upstreamEmissions);
+      this.indirectEmissionsPercent = sumValues(carbonEstimation.indirectEmissions);
+      this.directEmissionsPercent = sumValues(carbonEstimation.directEmissions);
+      this.downstreamEmissionsPercent = sumValues(carbonEstimation.downstreamEmissions);
+
+      this.upstreamEmissionsHeight = this.upstreamEmissionsPercent * 4;
+      this.indirectEmissionsHeight = this.indirectEmissionsPercent * 4;
+      this.directEmissionsHeight = this.directEmissionsPercent * 4;
+      this.downstreamEmissionsHeight = this.downstreamEmissionsPercent * 4;
     });
   }
 }

--- a/src/app/carbon-estimator.d.ts
+++ b/src/app/carbon-estimator.d.ts
@@ -2,10 +2,31 @@ import { FormControl, FormGroup } from '@angular/forms';
 
 export type CarbonEstimation = {
   version: string;
-  upstreamEmissions: number;
-  cloudEmissions: number;
-  directEmissions: number;
-  downstreamEmissions: number;
+  upstreamEmissions: UpstreamEstimation;
+  indirectEmissions: IndirectEstimation;
+  directEmissions: DirectEstimation;
+  downstreamEmissions: DownstreamEstimation;
+};
+
+export type UpstreamEstimation = {
+  software: number;
+  user: number;
+  network: number;
+  server: number;
+};
+export type IndirectEstimation = {
+  cloud: number;
+  saas: number;
+  managed: number;
+};
+export type DirectEstimation = {
+  user: number;
+  network: number;
+  server: number;
+};
+export type DownstreamEstimation = {
+  endUser: number;
+  network: number;
 };
 
 export type EstimatorValues = {

--- a/src/app/carbon-estimator/carbon-estimator.component.spec.ts
+++ b/src/app/carbon-estimator/carbon-estimator.component.spec.ts
@@ -12,10 +12,26 @@ describe('CarbonEstimatorComponent', () => {
     estimationServiceStub = {
       calculateCarbonEstimation: () => ({
         version: '0.0.0',
-        upstreamEmissions: 25,
-        cloudEmissions: 25,
-        directEmissions: 25,
-        downstreamEmissions: 25,
+        upstreamEmissions: {
+          software: 0,
+          user: 10,
+          network: 10,
+          server: 5,
+        },
+        indirectEmissions: {
+          saas: 0,
+          managed: 0,
+          cloud: 25,
+        },
+        directEmissions: {
+          user: 10,
+          network: 10,
+          server: 5,
+        },
+        downstreamEmissions: {
+          endUser: 15,
+          network: 10,
+        },
       }),
     };
 

--- a/src/app/estimation/estimate-direct-emissions.spec.ts
+++ b/src/app/estimation/estimate-direct-emissions.spec.ts
@@ -4,7 +4,11 @@ import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
 it('should return no emissions if all device counts are empty', () => {
   const deviceCounts = { laptopCount: 0, desktopCount: 0, serverCount: 0, networkCount: 0 };
-  expect(estimateDirectEmissions(deviceCounts, 'global')).toBe(0);
+  expect(estimateDirectEmissions(deviceCounts, 'global')).toEqual({
+    user: 0,
+    server: 0,
+    network: 0,
+  });
 });
 
 it('should return emissions from specified amounts of devices', () => {
@@ -14,8 +18,13 @@ it('should return emissions from specified amounts of devices', () => {
   const estimateServerEnergy = spyOn(server, 'estimateYearlyEnergy').and.returnValue(3);
   const estimateNetworkEnergy = spyOn(network, 'estimateYearlyEnergy').and.returnValue(4);
 
-  const totalEstimatedEmissions = estimateEnergyEmissions(10, 'global');
-  expect(estimateDirectEmissions(deviceCounts, 'global')).toBeCloseTo(totalEstimatedEmissions);
+  const threeEnergyEmissions = estimateEnergyEmissions(3, 'global');
+  const fourEnergyEmissions = estimateEnergyEmissions(4, 'global');
+  const result = estimateDirectEmissions(deviceCounts, 'global');
+  expect(result.user).toEqual(threeEnergyEmissions);
+  expect(result.server).toEqual(threeEnergyEmissions);
+  expect(result.network).toEqual(fourEnergyEmissions);
+
   expect(estimateLaptopEnergy).toHaveBeenCalledOnceWith(1);
   expect(estimateDesktopEnergy).toHaveBeenCalledOnceWith(2);
   expect(estimateServerEnergy).toHaveBeenCalledOnceWith(3);

--- a/src/app/estimation/estimate-direct-emissions.ts
+++ b/src/app/estimation/estimate-direct-emissions.ts
@@ -1,9 +1,8 @@
-import { DeviceCounts, WorldLocation } from '../carbon-estimator';
-import { KgCo2e } from '../types/units';
+import { DeviceCounts, DirectEstimation, WorldLocation } from '../carbon-estimator';
 import { desktop, laptop, network, server } from './device-type';
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
-export function estimateDirectEmissions(deviceCounts: DeviceCounts, onPremLocation: WorldLocation): KgCo2e {
+export function estimateDirectEmissions(deviceCounts: DeviceCounts, onPremLocation: WorldLocation): DirectEstimation {
   const desktopEnergy = desktop.estimateYearlyEnergy(deviceCounts.desktopCount);
   const laptopEnergy = laptop.estimateYearlyEnergy(deviceCounts.laptopCount);
   const serverEnergy = server.estimateYearlyEnergy(deviceCounts.serverCount);
@@ -14,5 +13,9 @@ export function estimateDirectEmissions(deviceCounts: DeviceCounts, onPremLocati
   const serverDirectEmissions = estimateEnergyEmissions(serverEnergy, onPremLocation);
   const networkDirectEmissions = estimateEnergyEmissions(networkEnergy, onPremLocation);
 
-  return desktopDirectEmissions + laptopDirectEmissions + serverDirectEmissions + networkDirectEmissions;
+  return {
+    user: desktopDirectEmissions + laptopDirectEmissions,
+    server: serverDirectEmissions,
+    network: networkDirectEmissions,
+  };
 }

--- a/src/app/estimation/estimate-downstream-emissions.spec.ts
+++ b/src/app/estimation/estimate-downstream-emissions.spec.ts
@@ -1,10 +1,6 @@
 import { Downstream } from '../carbon-estimator';
 import { estimateDownstreamEmissions } from './estimate-downstream-emissions';
 
-it('should return no emissions if no downstream info provided', () => {
-  expect(estimateDownstreamEmissions()).toBe(0);
-});
-
 it('should return no emissions if monthly active users is zero', () => {
   const input: Downstream = {
     monthlyActiveUsers: 0,
@@ -12,7 +8,10 @@ it('should return no emissions if monthly active users is zero', () => {
     mobilePercentage: 0,
     purposeOfSite: 'average',
   };
-  expect(estimateDownstreamEmissions(input)).toBe(0);
+  expect(estimateDownstreamEmissions(input)).toEqual({
+    endUser: 0,
+    network: 0,
+  });
 });
 
 it('should return emissions based on average values', () => {
@@ -22,5 +21,7 @@ it('should return emissions based on average values', () => {
     mobilePercentage: 0,
     purposeOfSite: 'average',
   };
-  expect(estimateDownstreamEmissions(input)).toBeCloseTo(552.439);
+  const result = estimateDownstreamEmissions(input);
+  expect(result.endUser).toBeCloseTo(302.839);
+  expect(result.network).toBeCloseTo(249.601);
 });

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -1,6 +1,6 @@
-import { PurposeOfSite, Downstream } from '../carbon-estimator';
+import { PurposeOfSite, Downstream, DownstreamEstimation } from '../carbon-estimator';
 import { estimateEnergyEmissions, getCarbonIntensity } from './estimate-energy-emissions';
-import { Gb, Hour, KgCo2e, KilowattHour } from '../types/units';
+import { Gb, Hour, KilowattHour } from '../types/units';
 import { AverageDeviceType, averagePersonalComputer, mobile } from './device-type';
 import { co2 } from '@tgwf/co2';
 
@@ -35,9 +35,9 @@ const siteTypeInfo: Record<PurposeOfSite, SiteInformation> = {
   },
 };
 
-export function estimateDownstreamEmissions(downstream?: Downstream): KgCo2e {
-  if (!downstream || downstream.monthlyActiveUsers === 0) {
-    return 0;
+export function estimateDownstreamEmissions(downstream: Downstream): DownstreamEstimation {
+  if (downstream.monthlyActiveUsers === 0) {
+    return { endUser: 0, network: 0 };
   }
 
   const downstreamDataTransfer = estimateDownstreamDataTransfer(
@@ -46,7 +46,7 @@ export function estimateDownstreamEmissions(downstream?: Downstream): KgCo2e {
   );
   const endUserEmissions = estimateEndUserEmissions(downstream, downstreamDataTransfer);
   const networkEmissions = estimateNetworkEmissions(downstream, downstreamDataTransfer);
-  return endUserEmissions + networkEmissions;
+  return { endUser: endUserEmissions, network: networkEmissions };
 }
 
 function estimateDownstreamDataTransfer(monthlyActiveUsers: number, purposeOfSite: PurposeOfSite): Gb {

--- a/src/app/estimation/estimate-indirect-emissions.spec.ts
+++ b/src/app/estimation/estimate-indirect-emissions.spec.ts
@@ -1,5 +1,5 @@
 import { Cloud } from '../carbon-estimator';
-import { estimateCloudEmissions } from './estimate-cloud-emissions';
+import { estimateIndirectEmissions } from './estimate-indirect-emissions';
 
 it('should return no emissions if cloud not used', () => {
   const input: Cloud = {
@@ -8,7 +8,12 @@ it('should return no emissions if cloud not used', () => {
     monthlyCloudBill: '5000-10000',
     cloudLocation: 'global',
   };
-  expect(estimateCloudEmissions(input)).toBe(0);
+  const result = estimateIndirectEmissions(input);
+  expect(result).toEqual({
+    cloud: 0,
+    saas: 0,
+    managed: 0,
+  });
 });
 
 it('should return emissions based on ratio of costs', () => {
@@ -18,5 +23,8 @@ it('should return emissions based on ratio of costs', () => {
     monthlyCloudBill: '0-200',
     cloudLocation: 'global',
   };
-  expect(estimateCloudEmissions(input)).toBeCloseTo(11.367);
+  const result = estimateIndirectEmissions(input);
+  expect(result.cloud).toBeCloseTo(11.367);
+  expect(result.saas).toBe(0);
+  expect(result.managed).toBe(0);
 });

--- a/src/app/estimation/estimate-indirect-emissions.ts
+++ b/src/app/estimation/estimate-indirect-emissions.ts
@@ -1,20 +1,24 @@
-import { Cloud, MonthlyCloudBill } from '../carbon-estimator';
+import { Cloud, IndirectEstimation, MonthlyCloudBill } from '../carbon-estimator';
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
-import { KgCo2e, KilowattHour } from '../types/units';
+import { KilowattHour } from '../types/units';
 
 // Calculated in spreadsheet, need some link to explanation
 const COST_TO_KWH_RATIO = 0.156;
 const AVERAGE_PUE = 1.18;
 
-export function estimateCloudEmissions(input: Cloud): KgCo2e {
+export function estimateIndirectEmissions(input: Cloud): IndirectEstimation {
   if (input.noCloudServices) {
-    return 0;
+    return {
+      cloud: 0,
+      saas: 0,
+      managed: 0,
+    };
   }
   const cloudEnergy = estimateCloudEnergy(input.monthlyCloudBill);
   const cloudDirectEmissions = estimateEnergyEmissions(cloudEnergy, input.cloudLocation);
   // TODO - Better method for cloud embodied carbon
   const cloudUpstreamEmissions = cloudDirectEmissions * (2 / 8);
-  return cloudDirectEmissions + cloudUpstreamEmissions;
+  return { cloud: cloudDirectEmissions + cloudUpstreamEmissions, saas: 0, managed: 0 };
 }
 
 function estimateCloudEnergy(monthlyCloudBill: MonthlyCloudBill): KilowattHour {

--- a/src/app/estimation/estimate-upstream-emissions.spec.ts
+++ b/src/app/estimation/estimate-upstream-emissions.spec.ts
@@ -3,7 +3,12 @@ import { estimateUpstreamEmissions } from './estimate-upstream-emissions';
 
 it('should return no emissions if all device counts are empty', () => {
   const deviceCounts = { laptopCount: 0, desktopCount: 0, serverCount: 0, networkCount: 0 };
-  expect(estimateUpstreamEmissions(deviceCounts)).toBe(0);
+  expect(estimateUpstreamEmissions(deviceCounts)).toEqual({
+    software: 0,
+    user: 0,
+    server: 0,
+    network: 0,
+  });
 });
 
 it('should return emissions from specified amounts of devices', () => {
@@ -13,7 +18,12 @@ it('should return emissions from specified amounts of devices', () => {
   const estimateServerEmissions = spyOn(server, 'estimateYearlyUpstreamEmissions').and.returnValue(3);
   const estimateNetworkEmissions = spyOn(network, 'estimateYearlyUpstreamEmissions').and.returnValue(4);
 
-  expect(estimateUpstreamEmissions(deviceCounts)).toBe(10);
+  expect(estimateUpstreamEmissions(deviceCounts)).toEqual({
+    software: 0,
+    user: 3,
+    server: 3,
+    network: 4,
+  });
   expect(estimateLaptopEmissions).toHaveBeenCalledOnceWith(1);
   expect(estimateDesktopEmissions).toHaveBeenCalledOnceWith(2);
   expect(estimateServerEmissions).toHaveBeenCalledOnceWith(3);

--- a/src/app/estimation/estimate-upstream-emissions.ts
+++ b/src/app/estimation/estimate-upstream-emissions.ts
@@ -1,12 +1,16 @@
-import { DeviceCounts } from '../carbon-estimator';
-import { KgCo2e } from '../types/units';
+import { DeviceCounts, UpstreamEstimation } from '../carbon-estimator';
 import { desktop, laptop, network, server } from './device-type';
 
-export function estimateUpstreamEmissions(deviceCounts: DeviceCounts): KgCo2e {
+export function estimateUpstreamEmissions(deviceCounts: DeviceCounts): UpstreamEstimation {
   const desktopUpstreamEmissions = desktop.estimateYearlyUpstreamEmissions(deviceCounts.desktopCount);
   const laptopUpstreamEmissions = laptop.estimateYearlyUpstreamEmissions(deviceCounts.laptopCount);
   const serverUpstreamEmissions = server.estimateYearlyUpstreamEmissions(deviceCounts.serverCount);
   const networkUpstreamEmissions = network.estimateYearlyUpstreamEmissions(deviceCounts.networkCount);
 
-  return desktopUpstreamEmissions + laptopUpstreamEmissions + serverUpstreamEmissions + networkUpstreamEmissions;
+  return {
+    software: 0,
+    user: desktopUpstreamEmissions + laptopUpstreamEmissions,
+    server: serverUpstreamEmissions,
+    network: networkUpstreamEmissions,
+  };
 }

--- a/src/app/services/carbon-estimation.service.spec.ts
+++ b/src/app/services/carbon-estimation.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { CarbonEstimationService } from './carbon-estimation.service';
 import { CarbonEstimation, EstimatorValues } from '../carbon-estimator';
 import { LoggingService } from './logging.service';
+import { sumValues } from '../utils/number-object';
 
 const emptyEstimatorValues: EstimatorValues = {
   upstream: {
@@ -29,15 +30,15 @@ const emptyEstimatorValues: EstimatorValues = {
 };
 
 function checkTotalPercentage(estimation: CarbonEstimation) {
-  expect(estimation.upstreamEmissions).toBeGreaterThanOrEqual(0);
-  expect(estimation.directEmissions).toBeGreaterThanOrEqual(0);
-  expect(estimation.cloudEmissions).toBeGreaterThanOrEqual(0);
-  expect(estimation.downstreamEmissions).toBeGreaterThanOrEqual(0);
+  expect(sumValues(estimation.upstreamEmissions)).toBeGreaterThanOrEqual(0);
+  expect(sumValues(estimation.directEmissions)).toBeGreaterThanOrEqual(0);
+  expect(sumValues(estimation.indirectEmissions)).toBeGreaterThanOrEqual(0);
+  expect(sumValues(estimation.downstreamEmissions)).toBeGreaterThanOrEqual(0);
   const total =
-    estimation.upstreamEmissions +
-    estimation.directEmissions +
-    estimation.cloudEmissions +
-    estimation.downstreamEmissions;
+    sumValues(estimation.upstreamEmissions) +
+    sumValues(estimation.directEmissions) +
+    sumValues(estimation.indirectEmissions) +
+    sumValues(estimation.downstreamEmissions);
   expect(total).toBeCloseTo(100);
 }
 
@@ -62,10 +63,10 @@ describe('CarbonEstimationService', () => {
     it('should include version and zeroed values in estimation', () => {
       const estimation = service.calculateCarbonEstimation(emptyEstimatorValues);
       expect(estimation.version).toBe('0.0.1');
-      expect(estimation.upstreamEmissions).toBe(0);
-      expect(estimation.directEmissions).toBe(0);
-      expect(estimation.cloudEmissions).toBe(0);
-      expect(estimation.downstreamEmissions).toBe(0);
+      expect(sumValues(estimation.upstreamEmissions)).toBe(0);
+      expect(sumValues(estimation.directEmissions)).toBe(0);
+      expect(sumValues(estimation.indirectEmissions)).toBe(0);
+      expect(sumValues(estimation.downstreamEmissions)).toBe(0);
     });
 
     it('should calculate estimations as percentages', () => {
@@ -83,18 +84,10 @@ describe('CarbonEstimationService', () => {
       service.calculateCarbonEstimation(emptyEstimatorValues);
       expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Input Values: .*/));
       expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Estimated Device Counts: .*/));
-      expect(loggingService.log).toHaveBeenCalledWith(
-        jasmine.stringMatching(/^Estimated Upstream Emissions: \d*\.?\d*kg CO2e$/)
-      );
-      expect(loggingService.log).toHaveBeenCalledWith(
-        jasmine.stringMatching(/^Estimated Direct Emissions: \d*\.?\d*kg CO2e$/)
-      );
-      expect(loggingService.log).toHaveBeenCalledWith(
-        jasmine.stringMatching(/^Estimated Cloud Emissions: \d*\.?\d*kg CO2e$/)
-      );
-      expect(loggingService.log).toHaveBeenCalledWith(
-        jasmine.stringMatching(/^Estimated Downstream Emissions: \d*\.?\d*kg CO2e$/)
-      );
+      expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Estimated Upstream Emissions: .*/));
+      expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Estimated Direct Emissions: .*/));
+      expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Estimated Indirect Emissions: .*/));
+      expect(loggingService.log).toHaveBeenCalledWith(jasmine.stringMatching(/^Estimated Downstream Emissions: .*/));
     });
   });
 

--- a/src/app/utils/number-object.spec.ts
+++ b/src/app/utils/number-object.spec.ts
@@ -1,0 +1,39 @@
+import { multiplyValues, sumValues } from './number-object';
+
+const basicObject = {
+  any: 1,
+  random: 2,
+  property: 3,
+};
+
+const anotherObject = {
+  here: 4,
+  are: 5,
+  more: 6,
+};
+
+type TestType = {
+  more: number;
+  properties: number;
+};
+
+describe('sumValues', () => {
+  it('should sum numerical values in any object', () => {
+    expect(sumValues(basicObject)).toBe(6);
+    expect(sumValues(anotherObject)).toBe(15);
+  });
+});
+
+describe('multiplyValues', () => {
+  it('should multiply all values in the input object', () => {
+    expect(multiplyValues(basicObject, 2)).toEqual({ any: 2, random: 4, property: 6 });
+  });
+  it('should retain input type', () => {
+    const input: TestType = {
+      more: 4,
+      properties: 5,
+    };
+    const output: TestType = multiplyValues(input, 3);
+    expect(output).toEqual({ more: 12, properties: 15 });
+  });
+});

--- a/src/app/utils/number-object.ts
+++ b/src/app/utils/number-object.ts
@@ -1,0 +1,13 @@
+export type NumberObject = { [s: string]: number };
+
+export function sumValues(input: NumberObject): number {
+  return Object.values(input).reduce((prev, curr) => prev + curr);
+}
+
+export function multiplyValues<T extends NumberObject>(input: T, factor: number): T {
+  const result: NumberObject = {};
+  for (const [key, value] of Object.entries(input)) {
+    result[key] = value * factor;
+  }
+  return result as T;
+}


### PR DESCRIPTION
Rename cloud references to indirect
Sum values to keep display the same for now (also changed their precision while I was there)