### PR TITLE
Use CO2.js for Carbon Intensity values

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -4,7 +4,7 @@ This page details the Angular components that are part of the application and ho
 
 ```mermaid
 flowchart TB
-  subgraph components
+  subgraph Components
     CarbonEstimator["`CarbonEstimatorComponent
     carbon-estimator`"]
     CarbonEstimatorForm["`CarbonEstimatorFormComponent
@@ -20,10 +20,11 @@ flowchart TB
     ExpansionPanel["`ExpansionPanelComponent
     expansion-panel`"]
   end
-  subgraph services
+  subgraph Services
     CarbonEstimationService
+    CarbonIntensityService
   end
-  subgraph pipes
+  subgraph Pipes
     FormatCostRangePipe
   end
 
@@ -32,6 +33,7 @@ flowchart TB
   CarbonEstimatorForm --> HelperInfo & Note
   CarbonEstimator & CarbonEstimatorForm ---> CarbonEstimationService
   CarbonEstimatorForm & CarbonEstimation --> ExpansionPanel
+  CarbonEstimationService & Assumptions --> CarbonIntensityService
 ```
 
 ## CarbonEstimatorComponent
@@ -52,7 +54,8 @@ Visualises the Carbon Estimation result.
 
 ## AssumptionsAndLimitationComponent
 
-Provides information on the Assumptions and Limitations of the estimation.
+Provides information on the Assumptions and Limitations of the estimation.  
+Uses the [CarbonIntensityService](services.md#carbonintensityservice) to get the latest carbon intensity figures to display.
 
 ## HelperInfoComponent
 

--- a/docs/estimation.md
+++ b/docs/estimation.md
@@ -18,13 +18,13 @@ classDiagram
 
     class estimate-indirect-emissions{
       <<module>>
-      +estimateIndirectEmissions(input: Cloud) IndirectEstimation
+      +estimateIndirectEmissions(input: Cloud, intensity: gCo2ePerKwh) IndirectEstimation
     }
 
     class estimate-downstream-emissions{
       <<module>>
       +siteTypeInfo: Record~PurposeOfSite, SiteInformation~
-      +estimateDownstreamEmissions(downstream: Downstream) DownstreamEstimation
+      +estimateDownstreamEmissions(downstream: Downstream, ...) DownstreamEstimation
     }
   }
 
@@ -107,6 +107,7 @@ Estimate emissions from Indirect categories
 ##### Parameters
 
 `input:`[`Cloud`](types.md#estimatorvalues) - The inputs relevant to cloud.
+`intensity:`[`gCo2ePerKwh`](types.md#units) - The Carbon intensity of the cloud region.
 
 ##### Returns
 
@@ -138,6 +139,7 @@ Estimate emissions from Downstream categories
 ##### Parameters
 
 `downstream:`[`Downstream`](types.md#estimatorvalues) - The inputs relevant to downstream emissions.
+`intensity:`[`gCo2ePerKwh`](types.md#units) - The Carbon intensity of the downstream region.
 
 ##### Returns
 
@@ -288,7 +290,7 @@ Creates device usage without exposing the exact method of calculation.
 
 `type:`[`DeviceType`](#devicetype) - The type of device being used.  
 `category:`[`DeviceCategory`](types#devicecategory) - The category the device usage falls under.  
-`location:`[`WorldLocation`](types#estimatorvalues) - The location the devices are being used in.  
+`intensity:`[`gCo2ePerKwh`](types#units) - The carbon intensity of the region the devices are being used in.  
 `count: number` - The number of devices being used.  
 `pue?: number` - The Power Usage Effectiveness of the device usage (optional, defaults to 1).  
 
@@ -307,7 +309,7 @@ Estimate emissions from energy used in a location.
 ##### Parameters
 
 `energy:`[`KilowattHour`](types.md#units) - Amount of energy used.  
-`location:`[`WorldLocation`](types.md#estimatorvalues) - The World Location where the energy was used for Carbon Intensity.
+`intensity:`[`gCo2ePerKwh`](types.md#units) - The Carbon Intensity of the region where the energy was used.
 
 ##### Returns
 

--- a/docs/estimation.md
+++ b/docs/estimation.md
@@ -51,9 +51,7 @@ classDiagram
 
     class estimate-energy-emissions {
       <<module>>
-      +locationIntensityMap: Record~WorldLocation, KgCo2ePerKwh~
       +estimateEnergyEmissions(...) KgCo2e
-      +getCarbonIntensity(...) gCo2ePerKwh
     }
   }
 
@@ -314,21 +312,3 @@ Estimate emissions from energy used in a location.
 ##### Returns
 
 [`KgCo2e`](types.md#units) - Kg of CO2e emitted via energy use.
-
-#### `getCarbonIntensity()`
-
-Exported to get Carbon Intensity in unit that [CO2.js](https://www.thegreenwebfoundation.org/co2-js/) library requires.
-
-##### Parameters
-
-`location:`[`WorldLocation`](types.md#estimatorvalues) - The World Location for Carbon Intensity.
-
-##### Returns
-
-[`gCo2ePerKwh`](types.md#units) - g of CO2e emitted per kWh of energy used.
-
-### Exported variables
-
-#### `locationIntensityMap: Record<WorldLocation, KgCo2ePerKwh>`
-
-Exported to allow use in assumptions component.

--- a/docs/services.md
+++ b/docs/services.md
@@ -6,10 +6,16 @@ This page details the Angular services that are part of the application.
 classDiagram
   class CarbonEstimationService{
     <<service>>
-    -loggingService: LoggingService 
+    -carbonIntensityService: CarbonIntensityService
+    -loggingService: LoggingService
     +calculateCarbonEstimation(formValue: EstimatorValues) CarbonEstimation
     +estimateServerCount(formValue: EstimatorValues) number
     -estimateDeviceUsage(formValue: EstimatorValues) DeviceUsage[]
+  }
+
+  class CarbonIntensityService{
+    <<service>>
+    +getCarbonIntensity(location: WorldLocation) gCo2ePerKwh
   }
 
   class LoggingService{
@@ -17,6 +23,7 @@ classDiagram
     +log(...output: any[])
   }
 
+  CarbonEstimationService --> "-carbonIntensityService" CarbonIntensityService
   CarbonEstimationService --> "-loggingService" LoggingService
 ```
 
@@ -30,6 +37,7 @@ The main service responsible for producing a carbon estimate.
 
 Takes input form values and uses them to calculate a carbon estimation.  
 Uses [LoggingService](#loggingservice) to output intermediate parts of the calculation.  
+Uses [CarbonIntensityService](#carbonintensityservice) to get the carbon intensity of input locations.
 Returns estimation as percentages.  
 Uses functions in other modules to perform the calculation.
 
@@ -57,13 +65,13 @@ classDiagram
 
     class estimate-indirect-emissions{
       <<module>>
-      +estimateIndirectEmissions(Cloud input) IndirectEstimation
+      +estimateIndirectEmissions(input: Cloud, intensity: gCo2ePerKwh) IndirectEstimation
     }
 
     class estimate-downstream-emissions{
       <<module>>
       +Record~PurposeOfSite, SiteInformation~ siteTypeInfo
-      +estimateDownstreamEmissions(Downstream downstream) DownstreamEstimation
+      +estimateDownstreamEmissions(Downstream downstream, intensity: gCo2ePerKwh) DownstreamEstimation
     }
   }
 
@@ -92,6 +100,24 @@ Method is used as part of [`calculateCarbonEstimation()`](#calculatecarbonestima
 ##### Returns
 
 `number` - The estimated server count given the current input.
+
+## CarbonIntensityService
+
+Currently a simple service to wrap the usage of the CO2.js library to reduce dependencies and allow a switch to a different provider in future.
+
+### Public Methods
+
+#### `getCarbonIntensity()`
+
+Gets a carbon intensity figure given a region.
+
+##### Parameters
+
+`location:`[`WorldLocation`](types.md#estimatorvalues) - The location to get the carbon intensity for.
+
+##### Returns
+
+[`gCo2ePerKwh`](types.md#units) - The carbon intensity of the location in grams of CO2 equivalent per Kilowatt hour of energy consumed.
 
 ## LoggingService
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -172,8 +172,6 @@ export type Watt = number;
 export type Hour = number;
 export type Year = number;
 export type KilowattHour = number;
-export type KgCo2ePerKwh = number;
-export type gCo2ePerKwh = number;
 export type KgCo2e = number;
 export type Gb = number;
 ```

--- a/docs/types.md
+++ b/docs/types.md
@@ -52,14 +52,14 @@ classDiagram
 
   class WorldLocation{
     <<union>>
-    'global'
-    'uk'
-    'europe'
-    'northAmerica'
-    'asia'
-    'africa'
-    'oceania'
-    'latinAmerica'
+    'WORLD'
+    'GBR'
+    'EUROPE'
+    'NORTH AMERICA'
+    'ASIA'
+    'AFRICA'
+    'OCEANIA'
+    'LATIN AMERICA AND CARIBBEAN'
   }
 
   class CostRange {

--- a/docs/types.md
+++ b/docs/types.md
@@ -173,6 +173,7 @@ export type Hour = number;
 export type Year = number;
 export type KilowattHour = number;
 export type KgCo2e = number;
+export type gCo2ePerKwh = number;
 export type Gb = number;
 ```
 

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -92,21 +92,21 @@
   <h4 class="text-lg">Carbon Intensity</h4>
   <p class="text-sm">
     We make use of the latest available Carbon Intensity figures from the
-    <a class="underline" href="https://ember-climate.org/data/data-tools/data-explorer/">Ember Data Explorer</a> for the
-    regions we make available. At present these are:
+    <a class="underline" href="https://ember-climate.org/data/data-tools/data-explorer/">Ember Data Explorer</a> via the
+    CO2.js library. We limit the range of regions that can be selected, which are currently:
   </p>
   <table class="w-fit">
     <thead>
       <tr>
         <th class="text-sm border border-slate-300 px-2 py-1 font-medium">World Location</th>
-        <th class="text-sm border border-slate-300 px-2 py-1 font-medium">Carbon Intensity (Kg CO2e/kWh)</th>
+        <th class="text-sm border border-slate-300 px-2 py-1 font-medium">Carbon Intensity (g CO2e/kWh)</th>
       </tr>
     </thead>
     <tbody>
       @for (item of locationCarbonInfo; track $index) {
         <tr>
           <td class="text-sm border border-slate-300 px-2 py-1">{{ item.location }}</td>
-          <td class="text-sm border border-slate-300 px-2 py-1">{{ item.carbonIntensity }}</td>
+          <td class="text-sm border border-slate-300 px-2 py-1">{{ item.carbonIntensity | number: '0.0-0' }}</td>
         </tr>
       }
     </tbody>

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -94,9 +94,10 @@
   </p>
   <h4 class="tce-text-lg">Carbon Intensity</h4>
   <p class="tce-text-sm">
-    We make use of the latest available Carbon Intensity figures from the
-    <a class="tce-underline" href="https://ember-climate.org/data/data-tools/data-explorer/">Ember Data Explorer</a> via
-    the CO2.js library. We limit the range of regions that can be selected, which are currently:
+    We make use of the latest available Carbon Intensity figures from
+    <a class="tce-underline" href="https://ember-climate.org/data/data-tools/data-explorer/">Ember</a> via the
+    <a class="tce-underline" href="https://www.thegreenwebfoundation.org/co2-js/">CO2.js</a> library. We limit the range
+    of regions that can be selected, which are currently:
   </p>
   <table class="tce-w-fit">
     <thead>

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -3,7 +3,7 @@ import { CLOUD_AVERAGE_PUE, ON_PREMISE_AVERAGE_PUE } from '../estimation/constan
 import { siteTypeInfo } from '../estimation/estimate-downstream-emissions';
 import { PurposeOfSite, WorldLocation, locationArray, purposeOfSiteArray } from '../types/carbon-estimator';
 import { DecimalPipe } from '@angular/common';
-import { locationIntensityMap } from '../estimation/estimate-energy-emissions';
+import { averageIntensity } from '@tgwf/co2';
 
 const purposeDescriptions: Record<PurposeOfSite, string> = {
   information: 'Information',
@@ -14,14 +14,14 @@ const purposeDescriptions: Record<PurposeOfSite, string> = {
 };
 
 const locationDescriptions: Record<WorldLocation, string> = {
-  global: 'Global',
-  northAmerica: 'North America',
-  europe: 'Europe',
-  uk: 'United Kingdom',
-  asia: 'Asia',
-  africa: 'Africa',
-  oceania: 'Oceania',
-  latinAmerica: 'Latin America and Caribbean',
+  WORLD: 'Global',
+  'NORTH AMERICA': 'North America',
+  EUROPE: 'Europe',
+  GBR: 'United Kingdom',
+  ASIA: 'Asia',
+  AFRICA: 'Africa',
+  OCEANIA: 'Oceania',
+  'LATIN AMERICA AND CARIBBEAN': 'Latin America and Caribbean',
 };
 
 @Component({
@@ -41,7 +41,7 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
   }));
   readonly locationCarbonInfo = locationArray.map(location => ({
     location: locationDescriptions[location],
-    carbonIntensity: locationIntensityMap[location],
+    carbonIntensity: averageIntensity.data[location],
   }));
 
   @ViewChild('assumptionsLimitation', { static: true }) public assumptionsLimitation!: ElementRef<HTMLDivElement>;

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -3,7 +3,7 @@ import { CLOUD_AVERAGE_PUE, ON_PREMISE_AVERAGE_PUE } from '../estimation/constan
 import { siteTypeInfo } from '../estimation/estimate-downstream-emissions';
 import { PurposeOfSite, WorldLocation, locationArray, purposeOfSiteArray } from '../types/carbon-estimator';
 import { DecimalPipe } from '@angular/common';
-import { averageIntensity } from '@tgwf/co2';
+import { CarbonIntensityService } from '../services/carbon-intensity.service';
 
 const purposeDescriptions: Record<PurposeOfSite, string> = {
   information: 'Information',
@@ -39,12 +39,16 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
     time: siteTypeInfo[purpose].averageMonthlyUserTime,
     data: siteTypeInfo[purpose].averageMonthlyUserData,
   }));
-  readonly locationCarbonInfo = locationArray.map(location => ({
-    location: locationDescriptions[location],
-    carbonIntensity: averageIntensity.data[location],
-  }));
+  readonly locationCarbonInfo;
 
   @ViewChild('assumptionsLimitation', { static: true }) public assumptionsLimitation!: ElementRef<HTMLDivElement>;
+
+  constructor(private intensityService: CarbonIntensityService) {
+    this.locationCarbonInfo = locationArray.map(location => ({
+      location: locationDescriptions[location],
+      carbonIntensity: this.intensityService.getCarbonIntensity(location),
+    }));
+  }
 
   public ngAfterContentInit(): void {
     this.assumptionsLimitation.nativeElement.focus();

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -10,14 +10,14 @@ import { FormatCostRangePipe } from '../pipes/format-cost-range.pipe';
 import { HelperInfoComponent } from '../helper-info/helper-info.component';
 
 const locationDescriptions: Record<WorldLocation, string> = {
-  global: 'Globally',
-  northAmerica: 'in North America',
-  europe: 'in Europe',
-  uk: 'in the UK',
-  asia: 'in Asia',
-  africa: 'in Africa',
-  oceania: 'in Oceania',
-  latinAmerica: 'in Latin America or the Caribbean',
+  WORLD: 'Globally',
+  'NORTH AMERICA': 'in North America',
+  EUROPE: 'in Europe',
+  GBR: 'in the UK',
+  ASIA: 'in Asia',
+  AFRICA: 'in Africa',
+  OCEANIA: 'in Oceania',
+  'LATIN AMERICA AND CARIBBEAN': 'in Latin America or the Caribbean',
 };
 
 @Component({
@@ -150,10 +150,10 @@ export class CarbonEstimatorFormComponent implements OnInit {
   public handleSubmit() {
     const formValue = this.estimatorForm.getRawValue();
     if (formValue.onPremise.serverLocation === 'unknown') {
-      formValue.onPremise.serverLocation = 'global';
+      formValue.onPremise.serverLocation = 'WORLD';
     }
     if (formValue.cloud.cloudLocation === 'unknown') {
-      formValue.cloud.cloudLocation = 'global';
+      formValue.cloud.cloudLocation = 'WORLD';
     }
     this.formSubmit.emit(formValue as EstimatorValues);
   }

--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -19,22 +19,22 @@ export const defaultValues: Required<EstimatorValues> = {
   upstream: {
     headCount: 100,
     desktopPercentage: 50,
-    employeeLocation: 'global',
+    employeeLocation: 'WORLD',
   },
   onPremise: {
     estimateServerCount: false,
-    serverLocation: 'global',
+    serverLocation: 'WORLD',
     numberOfServers: 10,
   },
   cloud: {
     noCloudServices: false,
-    cloudLocation: 'global',
+    cloudLocation: 'WORLD',
     cloudPercentage: 50,
     monthlyCloudBill: costRanges[0],
   },
   downstream: {
     noDownstream: false,
-    customerLocation: 'global',
+    customerLocation: 'WORLD',
     monthlyActiveUsers: 100,
     mobilePercentage: 50,
     purposeOfSite: 'average',

--- a/src/app/estimation/device-usage.spec.ts
+++ b/src/app/estimation/device-usage.spec.ts
@@ -4,15 +4,15 @@ import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
 describe('createDeviceUsage()', () => {
   it('should expose device category', () => {
-    expect(createDeviceUsage(laptop, 'user', 'WORLD', 0).category).toBe('user');
-    expect(createDeviceUsage(laptop, 'server', 'WORLD', 0).category).toBe('server');
-    expect(createDeviceUsage(laptop, 'network', 'WORLD', 0).category).toBe('network');
+    expect(createDeviceUsage(laptop, 'user', 0, 0).category).toBe('user');
+    expect(createDeviceUsage(laptop, 'server', 0, 0).category).toBe('server');
+    expect(createDeviceUsage(laptop, 'network', 0, 0).category).toBe('network');
   });
 
   it('should estimate upstream emissions using device type', () => {
     spyOn(laptop, 'estimateYearlyUpstreamEmissions').and.callFake(() => 42);
     const deviceCount = 10;
-    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount);
+    const usage = createDeviceUsage(laptop, 'user', 0, deviceCount);
 
     expect(usage.estimateUpstreamEmissions()).toBe(42);
     expect(laptop.estimateYearlyUpstreamEmissions).toHaveBeenCalledOnceWith(deviceCount);
@@ -21,9 +21,10 @@ describe('createDeviceUsage()', () => {
   it('should estimate direct emissions using device type and location', () => {
     spyOn(laptop, 'estimateYearlyEnergy').and.callFake(() => 42);
     const deviceCount = 100;
-    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount);
+    const carbonIntensity = 500;
+    const usage = createDeviceUsage(laptop, 'user', carbonIntensity, deviceCount);
 
-    const expectedEmissions = estimateEnergyEmissions(42, 'WORLD');
+    const expectedEmissions = estimateEnergyEmissions(42, carbonIntensity);
     expect(usage.estimateDirectEmissions()).toBe(expectedEmissions);
     expect(laptop.estimateYearlyEnergy).toHaveBeenCalledOnceWith(deviceCount);
   });
@@ -31,10 +32,11 @@ describe('createDeviceUsage()', () => {
   it('should apply pue to energy estimation if specified', () => {
     spyOn(laptop, 'estimateYearlyEnergy').and.callFake(() => 42);
     const deviceCount = 1000;
+    const carbonIntensity = 500;
     const pue = 2;
-    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount, pue);
+    const usage = createDeviceUsage(laptop, 'user', carbonIntensity, deviceCount, pue);
 
-    const expectedEmissions = estimateEnergyEmissions(84, 'WORLD');
+    const expectedEmissions = estimateEnergyEmissions(84, carbonIntensity);
     expect(usage.estimateDirectEmissions()).toBe(expectedEmissions);
     expect(laptop.estimateYearlyEnergy).toHaveBeenCalledOnceWith(deviceCount);
   });

--- a/src/app/estimation/device-usage.spec.ts
+++ b/src/app/estimation/device-usage.spec.ts
@@ -4,15 +4,15 @@ import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
 describe('createDeviceUsage()', () => {
   it('should expose device category', () => {
-    expect(createDeviceUsage(laptop, 'user', 'global', 0).category).toBe('user');
-    expect(createDeviceUsage(laptop, 'server', 'global', 0).category).toBe('server');
-    expect(createDeviceUsage(laptop, 'network', 'global', 0).category).toBe('network');
+    expect(createDeviceUsage(laptop, 'user', 'WORLD', 0).category).toBe('user');
+    expect(createDeviceUsage(laptop, 'server', 'WORLD', 0).category).toBe('server');
+    expect(createDeviceUsage(laptop, 'network', 'WORLD', 0).category).toBe('network');
   });
 
   it('should estimate upstream emissions using device type', () => {
     spyOn(laptop, 'estimateYearlyUpstreamEmissions').and.callFake(() => 42);
     const deviceCount = 10;
-    const usage = createDeviceUsage(laptop, 'user', 'global', deviceCount);
+    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount);
 
     expect(usage.estimateUpstreamEmissions()).toBe(42);
     expect(laptop.estimateYearlyUpstreamEmissions).toHaveBeenCalledOnceWith(deviceCount);
@@ -21,9 +21,9 @@ describe('createDeviceUsage()', () => {
   it('should estimate direct emissions using device type and location', () => {
     spyOn(laptop, 'estimateYearlyEnergy').and.callFake(() => 42);
     const deviceCount = 100;
-    const usage = createDeviceUsage(laptop, 'user', 'global', deviceCount);
+    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount);
 
-    const expectedEmissions = estimateEnergyEmissions(42, 'global');
+    const expectedEmissions = estimateEnergyEmissions(42, 'WORLD');
     expect(usage.estimateDirectEmissions()).toBe(expectedEmissions);
     expect(laptop.estimateYearlyEnergy).toHaveBeenCalledOnceWith(deviceCount);
   });
@@ -32,9 +32,9 @@ describe('createDeviceUsage()', () => {
     spyOn(laptop, 'estimateYearlyEnergy').and.callFake(() => 42);
     const deviceCount = 1000;
     const pue = 2;
-    const usage = createDeviceUsage(laptop, 'user', 'global', deviceCount, pue);
+    const usage = createDeviceUsage(laptop, 'user', 'WORLD', deviceCount, pue);
 
-    const expectedEmissions = estimateEnergyEmissions(84, 'global');
+    const expectedEmissions = estimateEnergyEmissions(84, 'WORLD');
     expect(usage.estimateDirectEmissions()).toBe(expectedEmissions);
     expect(laptop.estimateYearlyEnergy).toHaveBeenCalledOnceWith(deviceCount);
   });

--- a/src/app/estimation/device-usage.ts
+++ b/src/app/estimation/device-usage.ts
@@ -1,5 +1,5 @@
-import { DeviceCategory, WorldLocation } from '../types/carbon-estimator';
-import { KgCo2e } from '../types/units';
+import { DeviceCategory } from '../types/carbon-estimator';
+import { KgCo2e, gCo2ePerKwh } from '../types/units';
 import { DeviceType } from './device-type';
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
@@ -12,7 +12,7 @@ export interface DeviceUsage {
 export function createDeviceUsage(
   type: DeviceType,
   category: DeviceCategory,
-  location: WorldLocation,
+  intensity: gCo2ePerKwh,
   count: number,
   pue?: number
 ): DeviceUsage {
@@ -22,7 +22,7 @@ export function createDeviceUsage(
     estimateUpstreamEmissions: () => type.estimateYearlyUpstreamEmissions(count),
     estimateDirectEmissions: () => {
       const energy = type.estimateYearlyEnergy(count) * actualPue;
-      return estimateEnergyEmissions(energy, location);
+      return estimateEnergyEmissions(energy, intensity);
     },
   };
 }

--- a/src/app/estimation/estimate-downstream-emissions.spec.ts
+++ b/src/app/estimation/estimate-downstream-emissions.spec.ts
@@ -3,6 +3,8 @@ import { sumValues } from '../utils/number-object';
 import { estimateDownstreamEmissions } from './estimate-downstream-emissions';
 
 describe('estimateDownstreamEmissions()', () => {
+  const carbonIntensity = 500;
+
   it('should return no emissions if no downstream is requested', () => {
     const input: Downstream = {
       noDownstream: true,
@@ -11,7 +13,7 @@ describe('estimateDownstreamEmissions()', () => {
       mobilePercentage: 0,
       purposeOfSite: 'average',
     };
-    expect(estimateDownstreamEmissions(input)).toEqual({
+    expect(estimateDownstreamEmissions(input, carbonIntensity)).toEqual({
       endUser: 0,
       networkTransfer: 0,
     });
@@ -33,36 +35,36 @@ describe('estimateDownstreamEmissions()', () => {
   }
 
   it('should return emissions for information site', () => {
-    const result = estimateDownstreamEmissions(createInput('information'));
-    expectEmissionsCloseTo(result, { endUser: 0.5, networkTransfer: 0.05 });
+    const result = estimateDownstreamEmissions(createInput('information'), carbonIntensity);
+    expectEmissionsCloseTo(result, { endUser: 0.51, networkTransfer: 0.05 });
   });
 
   it('should return emissions for e-commerce site', () => {
-    const result = estimateDownstreamEmissions(createInput('eCommerce'));
-    expectEmissionsCloseTo(result, { endUser: 3.13888, networkTransfer: 1.11322 });
+    const result = estimateDownstreamEmissions(createInput('eCommerce'), carbonIntensity);
+    expectEmissionsCloseTo(result, { endUser: 3.18, networkTransfer: 1.1 });
   });
 
   it('should return emissions for social media site', () => {
-    const result = estimateDownstreamEmissions(createInput('socialMedia'));
-    expectEmissionsCloseTo(result, { endUser: 511.55, networkTransfer: 298.71 });
+    const result = estimateDownstreamEmissions(createInput('socialMedia'), carbonIntensity);
+    expectEmissionsCloseTo(result, { endUser: 517.851, networkTransfer: 296.41 });
   });
 
   it('should return emissions for streaming site', () => {
-    const result = estimateDownstreamEmissions(createInput('streaming'));
-    expectEmissionsCloseTo(result, { endUser: 694.93, networkTransfer: 698.42 });
+    const result = estimateDownstreamEmissions(createInput('streaming'), carbonIntensity);
+    expectEmissionsCloseTo(result, { endUser: 703.48, networkTransfer: 693.03 });
   });
 
   it('should return emissions based on average values', () => {
-    const result = estimateDownstreamEmissions(createInput('average'));
-    expectEmissionsCloseTo(result, { endUser: 302.53, networkTransfer: 249.57 });
+    const result = estimateDownstreamEmissions(createInput('average'), carbonIntensity);
+    expectEmissionsCloseTo(result, { endUser: 306.25, networkTransfer: 247.65 });
   });
 
   it('should create average equivalent to average of all other purposes', () => {
     const totalEmissions = basePurposeArray
-      .map(purpose => sumValues(estimateDownstreamEmissions(createInput(purpose))))
+      .map(purpose => sumValues(estimateDownstreamEmissions(createInput(purpose), carbonIntensity)))
       .reduce((x, y) => x + y);
     const expectedAverage = totalEmissions / basePurposeArray.length;
-    const result = estimateDownstreamEmissions(createInput('average'));
+    const result = estimateDownstreamEmissions(createInput('average'), carbonIntensity);
     expect(sumValues(result)).toBeCloseTo(expectedAverage);
   });
 });

--- a/src/app/estimation/estimate-downstream-emissions.spec.ts
+++ b/src/app/estimation/estimate-downstream-emissions.spec.ts
@@ -1,13 +1,13 @@
-import { Downstream, PurposeOfSite, basePurposeArray } from '../types/carbon-estimator';
+import { Downstream, DownstreamEstimation, PurposeOfSite, basePurposeArray } from '../types/carbon-estimator';
 import { sumValues } from '../utils/number-object';
 import { estimateDownstreamEmissions } from './estimate-downstream-emissions';
 
-describe('estimateDownstreamEmissions', () => {
+describe('estimateDownstreamEmissions()', () => {
   it('should return no emissions if no downstream is requested', () => {
     const input: Downstream = {
       noDownstream: true,
       monthlyActiveUsers: 100,
-      customerLocation: 'global',
+      customerLocation: 'WORLD',
       mobilePercentage: 0,
       purposeOfSite: 'average',
     };
@@ -21,40 +21,40 @@ describe('estimateDownstreamEmissions', () => {
     return {
       noDownstream: false,
       monthlyActiveUsers: 100,
-      customerLocation: 'global',
+      customerLocation: 'WORLD',
       mobilePercentage: 0,
       purposeOfSite: purposeOfSite,
     };
   }
 
+  function expectEmissionsCloseTo(actual: DownstreamEstimation, expected: DownstreamEstimation) {
+    expect(actual.endUser).withContext('endUser').toBeCloseTo(expected.endUser);
+    expect(actual.networkTransfer).withContext('networkTransfer').toBeCloseTo(expected.networkTransfer);
+  }
+
   it('should return emissions for information site', () => {
     const result = estimateDownstreamEmissions(createInput('information'));
-    expect(result.endUser).toBeCloseTo(0.50222);
-    expect(result.networkTransfer).toBeCloseTo(0.0525016);
+    expectEmissionsCloseTo(result, { endUser: 0.5, networkTransfer: 0.05 });
   });
 
   it('should return emissions for e-commerce site', () => {
     const result = estimateDownstreamEmissions(createInput('eCommerce'));
-    expect(result.endUser).toBeCloseTo(3.13888);
-    expect(result.networkTransfer).toBeCloseTo(1.11322);
+    expectEmissionsCloseTo(result, { endUser: 3.13888, networkTransfer: 1.11322 });
   });
 
   it('should return emissions for social media site', () => {
     const result = estimateDownstreamEmissions(createInput('socialMedia'));
-    expect(result.endUser).toBeCloseTo(511.637);
-    expect(result.networkTransfer).toBeCloseTo(298.761);
+    expectEmissionsCloseTo(result, { endUser: 511.55, networkTransfer: 298.71 });
   });
 
   it('should return emissions for streaming site', () => {
     const result = estimateDownstreamEmissions(createInput('streaming'));
-    expect(result.endUser).toBeCloseTo(695.038);
-    expect(result.networkTransfer).toBeCloseTo(698.533);
+    expectEmissionsCloseTo(result, { endUser: 694.93, networkTransfer: 698.42 });
   });
 
   it('should return emissions based on average values', () => {
     const result = estimateDownstreamEmissions(createInput('average'));
-    expect(result.endUser).toBeCloseTo(302.579);
-    expect(result.networkTransfer).toBeCloseTo(249.615);
+    expectEmissionsCloseTo(result, { endUser: 302.53, networkTransfer: 249.57 });
   });
 
   it('should create average equivalent to average of all other purposes', () => {

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -5,10 +5,10 @@ import {
   BasePurposeOfSite,
   basePurposeArray,
 } from '../types/carbon-estimator';
-import { estimateEnergyEmissions, getCarbonIntensity } from './estimate-energy-emissions';
+import { estimateEnergyEmissions } from './estimate-energy-emissions';
 import { Gb, Hour, KilowattHour } from '../types/units';
 import { AverageDeviceType, averagePersonalComputer, mobile } from './device-type';
-import { co2 } from '@tgwf/co2';
+import { co2, averageIntensity } from '@tgwf/co2';
 
 interface SiteInformation {
   averageMonthlyUserTime: Hour;
@@ -98,7 +98,7 @@ function estimateNetworkEmissions(downstream: Downstream, downstreamDataTransfer
   const options = {
     gridIntensity: {
       device: 0,
-      network: getCarbonIntensity(downstream.customerLocation),
+      network: averageIntensity.data[downstream.customerLocation],
       dataCenter: 0,
     },
   };

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -8,7 +8,7 @@ import {
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
 import { Gb, Hour, KilowattHour } from '../types/units';
 import { AverageDeviceType, averagePersonalComputer, mobile } from './device-type';
-import { co2, averageIntensity } from '@tgwf/co2';
+import { co2 } from '@tgwf/co2';
 
 interface SiteInformation {
   averageMonthlyUserTime: Hour;
@@ -98,7 +98,7 @@ function estimateNetworkEmissions(downstream: Downstream, downstreamDataTransfer
   const options = {
     gridIntensity: {
       device: 0,
-      network: averageIntensity.data[downstream.customerLocation],
+      network: { country: downstream.customerLocation },
       dataCenter: 0,
     },
   };

--- a/src/app/estimation/estimate-energy-emissions.spec.ts
+++ b/src/app/estimation/estimate-energy-emissions.spec.ts
@@ -1,19 +1,8 @@
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
-describe('Estimate Direct emissions', () => {
-  it('Should estimate emissions using global average', () => {
-    expect(estimateEnergyEmissions(1, 'WORLD')).toBeCloseTo(0.494);
-  });
-
-  it('Should estimate emissions using North America average', () => {
-    expect(estimateEnergyEmissions(1, 'NORTH AMERICA')).toBeCloseTo(0.378);
-  });
-
-  it('Should estimate emissions using europe average', () => {
-    expect(estimateEnergyEmissions(1, 'EUROPE')).toBeCloseTo(0.33);
-  });
-
-  it('Should estimate emissions using uk average', () => {
-    expect(estimateEnergyEmissions(1, 'GBR')).toBeCloseTo(0.256);
+describe('estimateEnergyEmissions()', () => {
+  it('Should estimate emissions using carbon intensity and convert to Kg', () => {
+    expect(estimateEnergyEmissions(1, 494)).toBeCloseTo(0.494);
+    expect(estimateEnergyEmissions(1000, 378)).toBeCloseTo(378);
   });
 });

--- a/src/app/estimation/estimate-energy-emissions.spec.ts
+++ b/src/app/estimation/estimate-energy-emissions.spec.ts
@@ -2,18 +2,18 @@ import { estimateEnergyEmissions } from './estimate-energy-emissions';
 
 describe('Estimate Direct emissions', () => {
   it('Should estimate emissions using global average', () => {
-    expect(estimateEnergyEmissions(1, 'global')).toBeCloseTo(0.494);
+    expect(estimateEnergyEmissions(1, 'WORLD')).toBeCloseTo(0.494);
   });
 
   it('Should estimate emissions using North America average', () => {
-    expect(estimateEnergyEmissions(1, 'northAmerica')).toBeCloseTo(0.356);
+    expect(estimateEnergyEmissions(1, 'NORTH AMERICA')).toBeCloseTo(0.378);
   });
 
   it('Should estimate emissions using europe average', () => {
-    expect(estimateEnergyEmissions(1, 'europe')).toBeCloseTo(0.33);
+    expect(estimateEnergyEmissions(1, 'EUROPE')).toBeCloseTo(0.33);
   });
 
   it('Should estimate emissions using uk average', () => {
-    expect(estimateEnergyEmissions(1, 'uk')).toBeCloseTo(0.238);
+    expect(estimateEnergyEmissions(1, 'GBR')).toBeCloseTo(0.256);
   });
 });

--- a/src/app/estimation/estimate-energy-emissions.ts
+++ b/src/app/estimation/estimate-energy-emissions.ts
@@ -1,22 +1,7 @@
-import { KgCo2e, KgCo2ePerKwh, KilowattHour, gCo2ePerKwh } from '../types/units';
+import { KgCo2e, KilowattHour } from '../types/units';
 import { WorldLocation } from '../types/carbon-estimator';
-
-// Carbon Intensity figures sourced from https://ember-climate.org/data/data-tools/data-explorer/
-export const locationIntensityMap: Record<WorldLocation, KgCo2ePerKwh> = {
-  global: 0.494,
-  northAmerica: 0.356,
-  europe: 0.328,
-  uk: 0.238,
-  asia: 0.591,
-  africa: 0.559,
-  oceania: 0.508,
-  latinAmerica: 0.26,
-};
+import { averageIntensity } from '@tgwf/co2';
 
 export function estimateEnergyEmissions(energy: KilowattHour, location: WorldLocation): KgCo2e {
-  return locationIntensityMap[location] * energy;
-}
-
-export function getCarbonIntensity(location: WorldLocation): gCo2ePerKwh {
-  return locationIntensityMap[location] * 1000;
+  return (averageIntensity.data[location] * energy) / 1000;
 }

--- a/src/app/estimation/estimate-energy-emissions.ts
+++ b/src/app/estimation/estimate-energy-emissions.ts
@@ -1,7 +1,5 @@
-import { KgCo2e, KilowattHour } from '../types/units';
-import { WorldLocation } from '../types/carbon-estimator';
-import { averageIntensity } from '@tgwf/co2';
+import { KgCo2e, KilowattHour, gCo2ePerKwh } from '../types/units';
 
-export function estimateEnergyEmissions(energy: KilowattHour, location: WorldLocation): KgCo2e {
-  return (averageIntensity.data[location] * energy) / 1000;
+export function estimateEnergyEmissions(energy: KilowattHour, intensity: gCo2ePerKwh): KgCo2e {
+  return (intensity * energy) / 1000;
 }

--- a/src/app/estimation/estimate-indirect-emissions.spec.ts
+++ b/src/app/estimation/estimate-indirect-emissions.spec.ts
@@ -1,30 +1,35 @@
 import { Cloud } from '../types/carbon-estimator';
 import { estimateIndirectEmissions } from './estimate-indirect-emissions';
 
-it('should return no emissions if cloud not used', () => {
-  const input: Cloud = {
-    noCloudServices: true,
-    cloudPercentage: 100,
-    monthlyCloudBill: { min: 5000, max: 10000 },
-    cloudLocation: 'WORLD',
-  };
-  const result = estimateIndirectEmissions(input);
-  expect(result).toEqual({
-    cloud: 0,
-    saas: 0,
-    managed: 0,
-  });
-});
+describe('estimateIndirectEmissions()', () => {
+  const carbonIntensity = 500;
 
-it('should return emissions based on ratio of costs, expanded to a years usage', () => {
-  const input: Cloud = {
-    noCloudServices: false,
-    cloudPercentage: 50,
-    monthlyCloudBill: { min: 0, max: 200 },
-    cloudLocation: 'WORLD',
-  };
-  const result = estimateIndirectEmissions(input);
-  expect(result.cloud).toBeCloseTo(128.78);
-  expect(result.saas).toBe(0);
-  expect(result.managed).toBe(0);
+  it('should return no emissions if cloud not used', () => {
+    const input: Cloud = {
+      noCloudServices: true,
+      cloudPercentage: 100,
+      monthlyCloudBill: { min: 5000, max: 10000 },
+      cloudLocation: 'WORLD',
+    };
+
+    const result = estimateIndirectEmissions(input, carbonIntensity);
+    expect(result).toEqual({
+      cloud: 0,
+      saas: 0,
+      managed: 0,
+    });
+  });
+
+  it('should return emissions based on ratio of costs, expanded to a years usage', () => {
+    const input: Cloud = {
+      noCloudServices: false,
+      cloudPercentage: 50,
+      monthlyCloudBill: { min: 0, max: 200 },
+      cloudLocation: 'WORLD',
+    };
+    const result = estimateIndirectEmissions(input, carbonIntensity);
+    expect(result.cloud).toBeCloseTo(130.13);
+    expect(result.saas).toBe(0);
+    expect(result.managed).toBe(0);
+  });
 });

--- a/src/app/estimation/estimate-indirect-emissions.spec.ts
+++ b/src/app/estimation/estimate-indirect-emissions.spec.ts
@@ -6,7 +6,7 @@ it('should return no emissions if cloud not used', () => {
     noCloudServices: true,
     cloudPercentage: 100,
     monthlyCloudBill: { min: 5000, max: 10000 },
-    cloudLocation: 'global',
+    cloudLocation: 'WORLD',
   };
   const result = estimateIndirectEmissions(input);
   expect(result).toEqual({
@@ -21,10 +21,10 @@ it('should return emissions based on ratio of costs, expanded to a years usage',
     noCloudServices: false,
     cloudPercentage: 50,
     monthlyCloudBill: { min: 0, max: 200 },
-    cloudLocation: 'global',
+    cloudLocation: 'WORLD',
   };
   const result = estimateIndirectEmissions(input);
-  expect(result.cloud).toBeCloseTo(10.733552 * 12);
+  expect(result.cloud).toBeCloseTo(128.78);
   expect(result.saas).toBe(0);
   expect(result.managed).toBe(0);
 });

--- a/src/app/estimation/estimate-indirect-emissions.ts
+++ b/src/app/estimation/estimate-indirect-emissions.ts
@@ -1,12 +1,12 @@
 import { Cloud, IndirectEstimation } from '../types/carbon-estimator';
 import { estimateEnergyEmissions } from './estimate-energy-emissions';
-import { KgCo2e, KilowattHour } from '../types/units';
+import { KgCo2e, KilowattHour, gCo2ePerKwh } from '../types/units';
 import { CLOUD_AVERAGE_PUE } from './constants';
 
 // Calculated in spreadsheet, explained in assumptions-and-limitation component
 const COST_TO_KWH_RATIO = 0.156;
 const COST_TO_UPSTREAM_RATIO = 0.0164;
-export function estimateIndirectEmissions(input: Cloud): IndirectEstimation {
+export function estimateIndirectEmissions(input: Cloud, cloudIntensity: gCo2ePerKwh): IndirectEstimation {
   if (input.noCloudServices) {
     return {
       cloud: 0,
@@ -16,7 +16,7 @@ export function estimateIndirectEmissions(input: Cloud): IndirectEstimation {
   }
   const midpoint = (input.monthlyCloudBill.min + input.monthlyCloudBill.max) / 2;
   const cloudEnergy = estimateCloudEnergy(midpoint);
-  const cloudDirectEmissions = estimateEnergyEmissions(cloudEnergy, input.cloudLocation);
+  const cloudDirectEmissions = estimateEnergyEmissions(cloudEnergy, cloudIntensity);
   const cloudUpstreamEmissions = estimateCloudUpstream(midpoint);
   return { cloud: cloudDirectEmissions + cloudUpstreamEmissions, saas: 0, managed: 0 };
 }

--- a/src/app/services/carbon-estimation.service.spec.ts
+++ b/src/app/services/carbon-estimation.service.spec.ts
@@ -10,22 +10,22 @@ const emptyEstimatorValues: EstimatorValues = {
   upstream: {
     headCount: 0,
     desktopPercentage: 0,
-    employeeLocation: 'global',
+    employeeLocation: 'WORLD',
   },
   onPremise: {
     estimateServerCount: false,
-    serverLocation: 'global',
+    serverLocation: 'WORLD',
     numberOfServers: 0,
   },
   cloud: {
     noCloudServices: true,
-    cloudLocation: 'global',
+    cloudLocation: 'WORLD',
     cloudPercentage: 0,
     monthlyCloudBill: { min: 0, max: 200 },
   },
   downstream: {
     noDownstream: true,
-    customerLocation: 'global',
+    customerLocation: 'WORLD',
     monthlyActiveUsers: 0,
     mobilePercentage: 0,
     purposeOfSite: 'streaming',
@@ -62,7 +62,7 @@ describe('CarbonEstimationService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('calculateCarbonEstimation', () => {
+  describe('calculateCarbonEstimation()', () => {
     it('should include version and zeroed values in estimation', () => {
       const estimation = service.calculateCarbonEstimation(emptyEstimatorValues);
       expect(estimation.version).toBe(version);
@@ -78,7 +78,7 @@ describe('CarbonEstimationService', () => {
         upstream: {
           headCount: 1,
           desktopPercentage: 0,
-          employeeLocation: 'global',
+          employeeLocation: 'WORLD',
         },
       });
       checkTotalPercentage(estimation);
@@ -100,11 +100,11 @@ describe('CarbonEstimationService', () => {
         upstream: {
           headCount: 4,
           desktopPercentage: 50,
-          employeeLocation: 'global',
+          employeeLocation: 'WORLD',
         },
         onPremise: {
           estimateServerCount: false,
-          serverLocation: 'global',
+          serverLocation: 'WORLD',
           numberOfServers: 2,
         },
       };
@@ -123,21 +123,21 @@ describe('CarbonEstimationService', () => {
         upstream: {
           headCount: 4,
           desktopPercentage: 50,
-          employeeLocation: 'uk',
+          employeeLocation: 'GBR',
         },
         onPremise: {
           estimateServerCount: false,
-          serverLocation: 'global',
+          serverLocation: 'WORLD',
           numberOfServers: 2,
         },
       };
       const result = service.calculateCarbonEstimation(hardwareInput);
-      expect(result.upstreamEmissions.user).withContext('upstreamEmissions.user').toBeCloseTo(3.74);
-      expect(result.upstreamEmissions.server).withContext('upstreamEmissions.server').toBeCloseTo(8.6);
-      expect(result.upstreamEmissions.network).withContext('upstreamEmissions.network').toBeCloseTo(3.85);
-      expect(result.directEmissions.user).withContext('directEmissions.user').toBeCloseTo(0.92);
-      expect(result.directEmissions.server).withContext('directEmissions.server').toBeCloseTo(64.87);
-      expect(result.directEmissions.network).withContext('directEmissions.network').toBeCloseTo(18.02);
+      expect(result.upstreamEmissions.user).withContext('upstreamEmissions.user').toBeCloseTo(3.72);
+      expect(result.upstreamEmissions.server).withContext('upstreamEmissions.server').toBeCloseTo(8.56);
+      expect(result.upstreamEmissions.network).withContext('upstreamEmissions.network').toBeCloseTo(3.84);
+      expect(result.directEmissions.user).withContext('directEmissions.user').toBeCloseTo(0.99);
+      expect(result.directEmissions.server).withContext('directEmissions.server').toBeCloseTo(64.54);
+      expect(result.directEmissions.network).withContext('directEmissions.network').toBeCloseTo(18.37);
     });
   });
 
@@ -152,11 +152,11 @@ describe('CarbonEstimationService', () => {
         upstream: {
           headCount: 100,
           desktopPercentage: 0,
-          employeeLocation: 'global',
+          employeeLocation: 'WORLD',
         },
         onPremise: {
           estimateServerCount: true,
-          serverLocation: 'global',
+          serverLocation: 'WORLD',
           numberOfServers: 0,
         },
       };
@@ -169,17 +169,17 @@ describe('CarbonEstimationService', () => {
         upstream: {
           headCount: 100,
           desktopPercentage: 0,
-          employeeLocation: 'global',
+          employeeLocation: 'WORLD',
         },
         onPremise: {
           estimateServerCount: true,
-          serverLocation: 'global',
+          serverLocation: 'WORLD',
           numberOfServers: 0,
         },
         cloud: {
           cloudPercentage: 50,
           noCloudServices: false,
-          cloudLocation: 'global',
+          cloudLocation: 'WORLD',
           monthlyCloudBill: { min: 0, max: 200 },
         },
       };

--- a/src/app/services/carbon-intensity.service.spec.ts
+++ b/src/app/services/carbon-intensity.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CarbonIntensityService } from './carbon-intensity.service';
+
+describe('CarbonIntensityService', () => {
+  let service: CarbonIntensityService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CarbonIntensityService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/carbon-intensity.service.ts
+++ b/src/app/services/carbon-intensity.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { gCo2ePerKwh } from '../types/units';
+import { WorldLocation } from '../types/carbon-estimator';
+import { averageIntensity } from '@tgwf/co2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CarbonIntensityService {
+  constructor() {}
+
+  getCarbonIntensity(location: WorldLocation): gCo2ePerKwh {
+    return averageIntensity.data[location];
+  }
+}

--- a/src/app/types/carbon-estimator.ts
+++ b/src/app/types/carbon-estimator.ts
@@ -90,14 +90,14 @@ export type Downstream = {
 export type DeviceCategory = 'user' | 'server' | 'network';
 
 export const locationArray = [
-  'global',
-  'uk',
-  'europe',
-  'northAmerica',
-  'asia',
-  'africa',
-  'oceania',
-  'latinAmerica',
+  'WORLD',
+  'GBR',
+  'EUROPE',
+  'NORTH AMERICA',
+  'ASIA',
+  'AFRICA',
+  'OCEANIA',
+  'LATIN AMERICA AND CARIBBEAN',
 ] as const;
 export type WorldLocation = (typeof locationArray)[number];
 

--- a/src/app/types/units.ts
+++ b/src/app/types/units.ts
@@ -2,7 +2,5 @@ export type Watt = number;
 export type Hour = number;
 export type Year = number;
 export type KilowattHour = number;
-export type KgCo2ePerKwh = number;
-export type gCo2ePerKwh = number;
 export type KgCo2e = number;
 export type Gb = number;

--- a/src/app/types/units.ts
+++ b/src/app/types/units.ts
@@ -3,4 +3,5 @@ export type Hour = number;
 export type Year = number;
 export type KilowattHour = number;
 export type KgCo2e = number;
+export type gCo2ePerKwh = number;
 export type Gb = number;


### PR DESCRIPTION
Also updated our WorldLocation to use the same format as CO2.js
Display the list in assumptions as grams instead of kilograms as it's easier to read and more commonly used form.
Updated some tests due to minor variations.