### PR TITLE
Ensure that form can always be submitted when opting out of end user calculations

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.spec.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.spec.ts
@@ -16,7 +16,26 @@ describe('CarbonEstimatorFormComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create component form in a valid state', () => {
     expect(component).toBeTruthy();
+    component.ngOnInit();
+    expect(component.estimatorForm.valid).toBeTruthy();
+  });
+
+  describe('Downstream', () => {
+    it('should invalidate form when monthly active users are zero', () => {
+      component.ngOnInit();
+      component.estimatorForm.get('downstream.monthlyActiveUsers')?.setValue(0);
+      fixture.detectChanges();
+      expect(component.estimatorForm.valid).toBeFalsy();
+    });
+
+    it('should validate form when downstream is excluded and monthly active users are zero', () => {
+      component.ngOnInit();
+      component.estimatorForm.get('downstream.monthlyActiveUsers')?.setValue(0);
+      component.estimatorForm.get('downstream.noDownstream')?.setValue(true);
+      fixture.detectChanges();
+      expect(component.estimatorForm.valid).toBeTruthy();
+    });
   });
 });

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -126,9 +126,15 @@ export class CarbonEstimatorFormComponent implements OnInit {
       this.changeDetector.detectChanges();
     });
 
-    this.estimatorForm
-      .get('downstream.noDownstream')
-      ?.valueChanges.subscribe(noDownstream => (this.noDownstream = noDownstream));
+    this.estimatorForm.get('downstream.noDownstream')?.valueChanges.subscribe(noDownstream => {
+      const monthlyActiveUsers = this.estimatorForm.get('downstream.monthlyActiveUsers');
+      if (noDownstream) {
+        monthlyActiveUsers?.disable();
+      } else {
+        monthlyActiveUsers?.enable();
+      }
+      this.noDownstream = noDownstream;
+    });
 
     this.estimatorForm.get('cloud.cloudPercentage')?.valueChanges.subscribe(cloudPercentage => {
       this.cloudPercentage = cloudPercentage;

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -134,6 +134,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
         monthlyActiveUsers?.enable();
       }
       this.noDownstream = noDownstream;
+      this.changeDetector.detectChanges();
     });
 
     this.estimatorForm.get('cloud.cloudPercentage')?.valueChanges.subscribe(cloudPercentage => {

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -161,6 +161,9 @@ export class CarbonEstimatorFormComponent implements OnInit {
     if (formValue.cloud.cloudLocation === 'unknown') {
       formValue.cloud.cloudLocation = 'WORLD';
     }
+    if (!formValue.downstream.monthlyActiveUsers) {
+      formValue.downstream.monthlyActiveUsers = 0;
+    }
     this.formSubmit.emit(formValue as EstimatorValues);
   }
 

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -94,7 +94,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
       downstream: this.formBuilder.nonNullable.group({
         noDownstream: [false],
         customerLocation: [defaultValues.downstream.customerLocation],
-        monthlyActiveUsers: [defaultValues.downstream.monthlyActiveUsers],
+        monthlyActiveUsers: [defaultValues.downstream.monthlyActiveUsers, Validators.required],
         mobilePercentage: [defaultValues.downstream.mobilePercentage],
         purposeOfSite: [defaultValues.downstream.purposeOfSite],
       }),


### PR DESCRIPTION
I think this is the best way to achieve this, found the following blog covering some options: https://netbasal.com/three-ways-to-dynamically-alter-your-form-validation-in-angular-e5fd15f1e946

1. Dynamically Add a Control - This seems like it could cause problems converting to `EstimatorValues` in `handleSubmit()`.
2. Dynamically Add Validators - We don't create the `MinValidator` explicitly so we can't remove it (the `min` in the `<input>` creates one automatically).
3. Disable the Control - Basically gives us what we want and works no matter how many validators the control has.

I also noticed that it was happy to submit when the value was deleted completely, the `required` validator prevents this. And even though we don't use the `monthlyActiveUsers` value when `noDownstream` is set, I thought it was safer to still make it zero rather than null in this case.