### PR TITLE
Add prepare script to allow estimator to be included via github url

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,7 +20,7 @@
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
-            "assets": [],
+            "assets": ["src/favicon.ico"],
             "styles": ["src/styles.css"],
             "scripts": []
           },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     "tailwindcss": "^3.4.1",
     "typescript": "~5.3.3"
   },
+  "files": [
+    "README.md",
+    "package.json",
+    "dist/**"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ScottLogic/sl-tech-carbon-estimator.git"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "prepare": "ng build",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,7 @@
     "typescript": "~5.3.3"
   },
   "files": [
-    "README.md",
-    "package.json",
-    "dist/**"
+    "dist/tech-carbon-estimator/**"
   ],
   "repository": {
     "type": "git",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -48,7 +48,7 @@ cp README.md package.json ./dist/tech-carbon-estimator/
 
 cd dist/tech-carbon-estimator
 
-npm pkg delete scripts private devDependencies
+npm pkg delete scripts private devDependencies files
 
 npm pkg set main=main.js
 


### PR DESCRIPTION
A prepare script will run when installing a dependency from a github repo url, so this will force npm to build the components when installing. The inclusion of a files property is necessary to include files in the package that would otherwise be excluded by the .gitignore file. It also excludes the unbuilt source and documentation that isn't needed but still includes the package.json and README. Also included favicon, which was missing from build until now.

This should allow us to add the estimator to TCS without relying on the npm registry or making a local link to the estimator. The latter option would not work with Github Actions. We may still publish to the npm registry so the publish script has been changed to remove the files entry, as it already moves all required files into a temporary directory.
