### PR TITLE
SFD-103 Update Network Calculations

### DIFF
--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -58,34 +58,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Laptop</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">17</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Desktop</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">72</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Server</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">400</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Network</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">150</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Mobile</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">1</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Tablet</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">3</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Monitor</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">30</td>
-      </tr>
+      @for (device of deviceInfo; track $index) {
+        <tr>
+          <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">{{ device.name }}</td>
+          <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">{{ device.info.averagePower }}</td>
+        </tr>
+      }
     </tbody>
   </table>
   <p class="tce-text-sm">
@@ -122,7 +100,7 @@
   <h4 class="tce-text-lg">Upstream Emissions</h4>
   <p class="tce-text-sm">
     Each class of device is given an average amount of embodied carbon and a lifespan, based on averages taken from
-    manufacturer provided Product Carbon Footprint documentation. At present these are:
+    manufacturer provided Product Carbon Footprint documentation*. At present these are:
   </p>
   <table class="tce-w-fit">
     <thead>
@@ -135,41 +113,17 @@
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Laptop</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">230</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">4</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Desktop</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">400</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">4</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Server</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">1450</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">4</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Network</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">650 *</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">4</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Mobile</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">54</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">3</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Tablet</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">134</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">3</td>
-      </tr>
-      <tr>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">Monitor</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">350</td>
-        <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">6</td>
-      </tr>
+      @for (device of deviceInfo; track $index) {
+        <tr>
+          <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">{{ device.name }}</td>
+          <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">
+            {{ device.info.averageEmbodiedCarbon }}
+          </td>
+          <td class="tce-text-sm tce-border tce-border-slate-300 tce-px-2 tce-py-1">
+            {{ device.info.averageLifespan }}
+          </td>
+        </tr>
+      }
     </tbody>
   </table>
   <p class="tce-text-sm tce-italic">

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -4,6 +4,7 @@ import { siteTypeInfo } from '../estimation/estimate-downstream-emissions';
 import { PurposeOfSite, WorldLocation, locationArray, purposeOfSiteArray } from '../types/carbon-estimator';
 import { DecimalPipe } from '@angular/common';
 import { CarbonIntensityService } from '../services/carbon-intensity.service';
+import { desktop, laptop, mobile, monitor, network, server, tablet } from '../estimation/device-type';
 
 const purposeDescriptions: Record<PurposeOfSite, string> = {
   information: 'Information',
@@ -40,6 +41,36 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
     data: siteTypeInfo[purpose].averageMonthlyUserData,
   }));
   readonly locationCarbonInfo;
+  readonly deviceInfo = [
+    {
+      name: 'Laptop',
+      info: laptop,
+    },
+    {
+      name: 'Desktop',
+      info: desktop,
+    },
+    {
+      name: 'Server',
+      info: server,
+    },
+    {
+      name: 'Network',
+      info: network,
+    },
+    {
+      name: 'Mobile',
+      info: mobile,
+    },
+    {
+      name: 'Tablet',
+      info: tablet,
+    },
+    {
+      name: 'Monitor',
+      info: monitor,
+    },
+  ];
 
   @ViewChild('assumptionsLimitation', { static: true }) public assumptionsLimitation!: ElementRef<HTMLDivElement>;
 

--- a/src/app/estimation/device-type.ts
+++ b/src/app/estimation/device-type.ts
@@ -55,7 +55,7 @@ export class AverageDeviceType extends DeviceType {
 export const laptop = new DeviceType(17, 8 * 230, 230, 4);
 export const desktop = new DeviceType(72, 8 * 230, 400, 4);
 export const server = new DeviceType(400, 24 * 365, 1450, 4);
-export const network = new DeviceType(150, 24 * 365, 650, 4);
+export const network = new DeviceType(87, 24 * 365, 650, 4);
 export const mobile = new DeviceType(1, 24 * 365, 54, 3);
 export const tablet = new DeviceType(3, 24 * 365, 134, 3);
 export const monitor = new DeviceType(30, 8 * 230, 350, 6);

--- a/src/app/services/carbon-estimation.service.ts
+++ b/src/app/services/carbon-estimation.service.ts
@@ -62,7 +62,7 @@ export class CarbonEstimationService {
     const desktopCount = calculateCeilingPercentage(desktopPercent, headCount);
     const laptopCount = calculateCeilingPercentage(laptopPercent, headCount);
     const serverCount = this.estimateServerCount(formValue);
-    const employeeNetworkCount = estimateNetworkDeviceCount(desktopCount);
+    const employeeNetworkCount = estimateNetworkDeviceCount(desktopCount + laptopCount);
     const serverNetworkCount = estimateNetworkDeviceCount(serverCount);
     const monitorCount = headCount;
 
@@ -75,7 +75,7 @@ export class CarbonEstimationService {
     return [
       createDeviceUsage(desktop, 'user', employeeIntensity, desktopCount),
       createDeviceUsage(laptop, 'user', employeeIntensity, laptopCount),
-      createDeviceUsage(network, 'network', employeeIntensity, employeeNetworkCount, ON_PREMISE_AVERAGE_PUE),
+      createDeviceUsage(network, 'network', employeeIntensity, employeeNetworkCount),
       createDeviceUsage(server, 'server', onPremIntensity, serverCount, ON_PREMISE_AVERAGE_PUE),
       createDeviceUsage(network, 'network', onPremIntensity, serverNetworkCount, ON_PREMISE_AVERAGE_PUE),
       createDeviceUsage(monitor, 'user', employeeIntensity, monitorCount),
@@ -107,7 +107,7 @@ function calculateCeilingPercentage(percentage: number, value: number) {
 }
 
 function estimateNetworkDeviceCount(deviceCount: number) {
-  return Math.ceil(deviceCount / 2);
+  return Math.ceil(deviceCount / 16);
 }
 
 function formatObject(input: unknown): string {


### PR DESCRIPTION
Calculation changes:

- Reduce the average power to 87W 
- Remove the 1.58 PUE multiplication for networking attributed to employee hardware
- Calculate number of network devices by dividing other hardware count by 16
- Include laptops in hardware count

I have also moved to having the assumptions and limitations component display figures from the DeviceType class itself. I almost considered making the devices part of a device service, rather than build up the list in the component but I think that could be a later addition.