### PR TITLE
Custom styling for Scott Logic version of Estimator

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -21,7 +21,7 @@
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico"],
-            "styles": ["src/styles.css"],
+            "styles": ["src/styles.css", "src/sl-styles.css"],
             "scripts": []
           },
           "configurations": {
@@ -41,6 +41,8 @@
               "baseHref": "/sl-tech-carbon-estimator/"
             },
             "npm-package": {
+              "assets": [],
+              "styles": ["src/styles.css"]
             },
             "development": {
               "optimization": false,

--- a/angular.json
+++ b/angular.json
@@ -40,6 +40,8 @@
               ],
               "baseHref": "/sl-tech-carbon-estimator/"
             },
+            "npm-package": {
+            },
             "development": {
               "optimization": false,
               "extractLicenses": false,
@@ -53,6 +55,9 @@
           "configurations": {
             "production": {
               "buildTarget": "tech-carbon-estimator:build:production"
+            },
+            "npm-package": {
+              "buildTarget": "tech-carbon-estimator:build:npm-package"
             },
             "development": {
               "buildTarget": "tech-carbon-estimator:build:development"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "prepare": "ng build",
+    "prepare": "ng build --configuration npm-package",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -34,7 +34,7 @@ fi
 rm -rf /dist/tech-carbon-estimator
 
 # Build and test
-npm run build
+npm run prepare
 
 npm run test
 

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -340,7 +340,7 @@
     We currently do not make a distinction between on-premises data centers and those ran by a third party.
   </p>
   <button
-    class="tce-px-3 tce-py-2 tce-bg-sky-800 tce-text-white tce-rounded hover:tce-bg-sky-900 tce-self-end"
+    class="tce-button-close tce-px-3 tce-py-2 tce-self-end"
     (click)="onClose()"
     aria-label="Close assumptions and limitations">
     Close

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -235,17 +235,12 @@
 
   <div class="tce-flex tce-gap-4 tce-flex-row-reverse">
     <button
-      class="tce-px-3 tce-py-2 tce-bg-sky-800 tce-text-white tce-rounded disabled:tce-opacity-50 disabled:tce-cursor-not-allowed hover:tce-bg-sky-900"
+      class="tce-button-calculate tce-px-3 tce-py-2 disabled:tce-opacity-50 disabled:tce-cursor-not-allowed"
       type="submit"
       [disabled]="!estimatorForm.valid">
       Calculate
     </button>
-    <button
-      class="tce-px-3 tce-py-2 tce-bg-slate-200 tce-text-slate-800 tce-rounded hover:tce-bg-slate-300"
-      type="button"
-      (click)="resetForm()">
-      Reset
-    </button>
+    <button class="tce-button-reset tce-px-3 tce-py-2" type="button" (click)="resetForm()">Reset</button>
   </div>
 
   <ng-template

--- a/src/app/note/note.component.html
+++ b/src/app/note/note.component.html
@@ -1,5 +1,4 @@
-<div
-  class="tce-p-4 tce-flex tce-gap-4 tce-bg-sky-200 tce-border tce-border-sky-400 tce-rounded tce-text-sm tce-text-slate-800">
+<div class="tce-note tce-p-4 tce-flex tce-gap-4 tce-border tce-rounded tce-text-sm">
   <span class="material-icons-outlined tce-flex tce-my-auto">info</span>
   <ng-content></ng-content>
 </div>

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -21,7 +21,7 @@
         @if (!showAssumptionsAndLimitationView) {
           <button
             id="showAssumptionsAndLimitationButton"
-            class="tce-px-3 tce-py-2 tce-bg-slate-200 tce-text-slate-800 tce-rounded hover:tce-bg-slate-300 tce-w-fit tce-self-end"
+            class="tce-button-assumptions tce-px-3 tce-py-2 tce-w-fit tce-self-end"
             (click)="showAssumptionsAndLimitation()">
             Assumptions and limitations
           </button>

--- a/src/sl-styles.css
+++ b/src/sl-styles.css
@@ -22,3 +22,14 @@
 input {
   accent-color: var(--primary-turquoise);
 }
+
+.tce-button-calculate, .tce-button-reset, .tce-button-assumptions, .tce-button-close {
+  color: var(--primary-charcoal);
+  border-color: var(--primary-turquoise);
+  @apply tce-rounded-none tce-border-b-4 tce-bg-transparent
+}
+
+.tce-button-calculate:hover, .tce-button-reset:hover, .tce-button-assumptions:hover, .tce-button-close:hover {
+  background-color: var(--primary-turquoise);
+  @apply tce-text-white
+}

--- a/src/sl-styles.css
+++ b/src/sl-styles.css
@@ -1,0 +1,20 @@
+:root {
+  --primary-charcoal: #252525;
+  --primary-turquoise: #2bb3bb;
+  --primary-pink: #c41565;
+  --primary-orange: #ef8547;
+  --secondary-yellow: #f8be4f;
+  --secondary-green: #7fc45f;
+  --secondary-turquoise: #dff0f3;
+  --secondary-pink: #f9eaf1;
+  --secondary-orange: #fdede4;
+  --secondary-light-yellow: #fef9ef;
+  --secondary-light-green: #f2faef;
+  color: var(--primary-charcoal);
+}
+
+.tce-note {
+  background-color: var(--secondary-turquoise);
+  border-color: var(--primary-turquoise);
+  color: var(--primary-charcoal);
+}

--- a/src/sl-styles.css
+++ b/src/sl-styles.css
@@ -18,3 +18,7 @@
   border-color: var(--primary-turquoise);
   color: var(--primary-charcoal);
 }
+
+input {
+  accent-color: var(--primary-turquoise);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
+.tce-note {
+  @apply tce-bg-sky-200 tce-border-sky-400 tce-text-slate-800
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,3 +5,11 @@
 .tce-note {
   @apply tce-bg-sky-200 tce-border-sky-400 tce-text-slate-800
 }
+
+.tce-button-calculate, .tce-button-close {
+  @apply tce-bg-sky-800 tce-text-white hover:tce-bg-sky-900 tce-rounded
+}
+
+.tce-button-reset, .tce-button-assumptions {
+  @apply tce-bg-slate-200 tce-text-slate-800 hover:tce-bg-slate-300 tce-rounded
+}


### PR DESCRIPTION
- Added additional configuration to build for npm package using original styling
- Use Primary/Secondary turquoise and Charcoal for production build
  - Notes Component
  - Input sliders
  - Main buttons (with border-bottom and no radius)

**Notes**
![image](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/117279304/d4540176-cdaf-408b-a3ae-a5ce491ee631)

**Sliders & Buttons**
![image](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/117279304/4bb4ddc3-6a95-43aa-9e84-d39651887e78)

**Buttons (on hover)**
![image](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/117279304/f43ea505-e922-4339-b5db-1118e28ea2ca)

Adding @jcamilleri-scottlogic and @dkrees for review in case @jantoun-scottlogic is still out tomorrow.
