### PR TITLE
Tweak button styling to match Scott Logic site

### DIFF
--- a/src/sl-styles.css
+++ b/src/sl-styles.css
@@ -26,7 +26,7 @@ input {
 .tce-button-calculate, .tce-button-reset, .tce-button-assumptions, .tce-button-close {
   color: var(--primary-charcoal);
   border-color: var(--primary-turquoise);
-  @apply tce-rounded-none tce-border-b-4 tce-bg-transparent
+  @apply tce-rounded-none tce-border-b-[3px] tce-bg-transparent tce-p-0.5
 }
 
 .tce-button-calculate:hover, .tce-button-reset:hover, .tce-button-assumptions:hover, .tce-button-close:hover {


### PR DESCRIPTION
Had to specify border width as a one off value as tailwind doesn't have 3 by default, p-0.5 = padding: 0.125rem, which is what the site uses.