### PR TITLE
SFD-126: Inline error message for monthly active users field is formatted incorrectly on smaller screen sizes bugfix

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -16,9 +16,10 @@
           min="1"
           aria-describedby="headCountError" />
         @if (headCount?.invalid && (headCount?.dirty || headCount?.touched)) {
-          <p class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="headCountError">
-            <span class="material-icons-outlined tce-flex">error</span>The number of employees must be greater than 0.
-          </p>
+          <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="headCountError">
+            <span class="material-icons-outlined tce-flex">error</span>
+            <p>The number of employees must be greater than 0.</p>
+          </div>
         }
       </div>
 

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -204,10 +204,13 @@
             min="1"
             aria-describedby="monthlyActiveUsersError" />
           @if (monthlyActiveUsers?.invalid && (monthlyActiveUsers?.dirty || monthlyActiveUsers?.touched)) {
-            <p class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
-              <span class="material-icons-outlined tce-flex">error</span>Monthly active users must be greater than 0. To
-              specify no external users, use the <a class="tce-underline" href="#noDownstream">checkbox</a> above.
-            </p>
+            <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
+              <span class="material-icons-outlined tce-flex">error</span>
+              <p>
+                Monthly active users must be greater than 0. To specify no external users, use the
+                <a class="tce-underline" href="#noDownstream">checkbox</a> above.
+              </p>
+            </div>
           }
         </div>
 

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -17,7 +17,7 @@
           aria-describedby="headCountError" />
         @if (headCount?.invalid && (headCount?.dirty || headCount?.touched)) {
           <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="headCountError">
-            <span class="material-icons-outlined tce-flex">error</span>
+            <span class="material-icons-outlined">error</span>
             <p>The number of employees must be greater than 0.</p>
           </div>
         }
@@ -206,7 +206,7 @@
             aria-describedby="monthlyActiveUsersError" />
           @if (monthlyActiveUsers?.invalid && (monthlyActiveUsers?.dirty || monthlyActiveUsers?.touched)) {
             <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
-              <span class="material-icons-outlined tce-flex">error</span>
+              <span class="material-icons-outlined">error</span>
               <p>
                 Monthly active users must be greater than 0. To specify no external users, use the
                 <a class="tce-underline" href="#noDownstream">checkbox</a> above.


### PR DESCRIPTION
[SFD-126 Jira Ticket](https://scottlogic.atlassian.net/browse/SFD-126)

Fixes an issue where the error message for the monthly active users field would be broken up and formatted incorrectly on smaller screen sizes.

Issue:
![error-message-formatting-bug](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/12c6f3bb-4252-4c34-94bc-bef2ea31ed9f)

After fix:
![error-message-after-fix](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/e05ab7c9-c821-4038-8271-901f9f0f0778)

