### PR TITLE
SFD-124: Limit the size/shape that the diagram can be

### DIFF
--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -72,7 +72,7 @@ describe('CarbonEstimationComponent', () => {
     component.onResize(2000, 1000, 2000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 1400 }, // Height will be capped at a percentage of the screen height
+      chart: { height: 1500 }, // Height will be capped at a percentage of the screen height
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -72,7 +72,7 @@ describe('CarbonEstimationComponent', () => {
     component.onResize(2000, 1000, 2000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 2000 * 0.7 }, // Height will be capped at screenHeight * 0.7
+      chart: { height: 1400 }, // Height will be capped at a percentage of the screen height
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -69,10 +69,10 @@ describe('CarbonEstimationComponent', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(2000, 1000);
+    component.onResize(2000, 1000, 2000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 2000 - estimatorBaseHeight - 200 },
+      chart: { height: 2000 * 0.7 }, // Height will be capped at screenHeight * 0.7
     });
   });
 
@@ -80,7 +80,7 @@ describe('CarbonEstimationComponent', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(1000, 500);
+    component.onResize(1000, 500, 1000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
       chart: { height: 1000 - estimatorBaseHeight - 200 + estimatorHeights.title },

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -138,21 +138,22 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   private getChartHeight(innerHeight: number, innerWidth: number, screenHeight: number): number {
     const expansionPanelHeight = this.detailsPanel.nativeElement.clientHeight;
 
+    let calculatedHeight: number;
+
     // medium tailwind responsive design breakpoint https://tailwindcss.com/docs/responsive-design
     if (innerWidth < 768) {
-      return innerHeight - this.estimatorBaseHeight - expansionPanelHeight + estimatorHeights.title;
+      calculatedHeight = innerHeight - this.estimatorBaseHeight - expansionPanelHeight + estimatorHeights.title;
+    } else {
+      const extraHeightString = this.extraHeight();
+      const extraHeight = Number(extraHeightString) || 0;
+      calculatedHeight = innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight;
     }
 
-    const extraHeightString = this.extraHeight();
-    const extraHeight = Number(extraHeightString) || 0;
     const maxScreenHeightRatio = 0.7;
 
     // Cap height based on screen height to prevent issues with chart becoming
     // stretched when the component is displayed in a tall iFrame
-    return Math.min(
-      innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight,
-      screenHeight * maxScreenHeightRatio
-    );
+    return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
   }
 
   private getDataItem(key: string, value: number, parent: string): ApexChartDataItem {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -149,10 +149,10 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
       calculatedHeight = innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight;
     }
 
-    const maxScreenHeightRatio = 0.7;
+    const maxScreenHeightRatio = 0.75;
 
-    // Cap height based on screen height to prevent issues with chart becoming
-    // stretched when the component is displayed in a tall iFrame
+    // Cap chart height based on screen height to prevent issues with the chart
+    // becoming stretched when the component is displayed in a tall iFrame
     return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
   }
 

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -145,10 +145,14 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
     const extraHeightString = this.extraHeight();
     const extraHeight = Number(extraHeightString) || 0;
+    const maxScreenHeightRatio = 0.7;
 
     // Cap height based on screen height to prevent issues with chart becoming
     // stretched when the component is displayed in a tall iFrame
-    return Math.min(innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight, screenHeight * 0.7);
+    return Math.min(
+      innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight,
+      screenHeight * maxScreenHeightRatio
+    );
   }
 
   private getDataItem(key: string, value: number, parent: string): ApexChartDataItem {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -138,22 +138,23 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   private getChartHeight(innerHeight: number, innerWidth: number, screenHeight: number): number {
     const expansionPanelHeight = this.detailsPanel.nativeElement.clientHeight;
 
-    let calculatedHeight: number;
-
-    // medium tailwind responsive design breakpoint https://tailwindcss.com/docs/responsive-design
-    if (innerWidth < 768) {
-      calculatedHeight = innerHeight - this.estimatorBaseHeight - expansionPanelHeight + estimatorHeights.title;
-    } else {
-      const extraHeightString = this.extraHeight();
-      const extraHeight = Number(extraHeightString) || 0;
-      calculatedHeight = innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight;
-    }
+    const calculatedHeight = this.calculateChartHeight(innerHeight, innerWidth, expansionPanelHeight);
 
     const maxScreenHeightRatio = 0.75;
 
     // Cap chart height based on screen height to prevent issues with the chart
     // becoming stretched when the component is displayed in a tall iFrame
     return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
+  }
+
+  private calculateChartHeight(innerHeight: number, innerWidth: number, expansionPanelHeight: number) {
+    // medium tailwind responsive design breakpoint https://tailwindcss.com/docs/responsive-design
+    if (innerWidth < 768) {
+      return innerHeight - this.estimatorBaseHeight - expansionPanelHeight + estimatorHeights.title;
+    }
+    const extraHeightString = this.extraHeight();
+    const extraHeight = Number(extraHeightString) || 0;
+    return innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight;
   }
 
   private getDataItem(key: string, value: number, parent: string): ApexChartDataItem {


### PR DESCRIPTION
[SFD-124 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-124)

Caps the chart height based on screen height to prevent issues with the chart becoming stretched when the component is displayed in a tall iFrame.

In iFrame before fix:
![in-iframe-without-fix](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/abef607a-753f-4b2f-b9c3-9a7afdc75c42)

In iFrame after fix:
![in-iframe-with-fix](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/18d83786-1896-4bb8-b2cf-7f613b08f70d)

I've capped based on screen height rather than aspect ratio for the time being, mostly due to the screen height cap seeming to work ok and being unfamiliar with using aspect ratio to set height and how it would work in various contexts. I think it looks ok on mobile views (checked with the Chrome device toggle) and laptop but we might need to revisit and use aspect ratio if we aren't getting the desired effect in some settings.