### PR TITLE
Missed requirements.txt when adding xprocess

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,12 @@ iniconfig==2.0.0
 packaging==24.1
 playwright==1.44.0
 pluggy==1.5.0
+psutil==5.9.8
 pyee==11.1.0
 pytest==8.2.2
 pytest-base-url==2.1.0
 pytest-playwright==0.5.0
+pytest-xprocess==1.0.2
 python-slugify==8.0.4
 requests==2.32.3
 text-unidecode==1.3


### PR DESCRIPTION
Would like to get this in separately from the automation as I don't know how long that will take to get right.