### PR TITLE
SFD-98: Chart scaling on zoom bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The tech carbon estimator is a web component that allow you to estimate, at high
 
 exposed as a web component `tech-carbon-estimator`. The component takes the follow optional input:
 
-- `extra-height` - this is extra height to be added whe calculating the height if the chart. eg a header/footer that will be visible on the page
+- `extra-height` - this is extra height to be taken into account when calculating the height of the chart. E.g. the height of a header/footer that will be visible on the page.
 
 You will need to import the following files to use the tech-carbon-estimator:
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -48,11 +48,16 @@ describe('CarbonEstimationComponent', () => {
   });
 
   it('should set chart height when inner height is more than base height', () => {
+    console.log(`window.innerHeight: ${window.innerHeight}`);
     spyOnProperty(window, 'innerHeight').and.returnValue(1000);
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
     component.ngOnInit();
     fixture.detectChanges();
+
+    console.log(`window.innerHeight: ${window.innerHeight}`);
+    console.log(`screen height: ${window.screen.height}`);
+    console.log(`device pixel ratio: ${window.devicePixelRatio}`);
 
     expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200);
   });

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -87,14 +87,16 @@ describe('CarbonEstimationComponent', () => {
     });
   });
 
-  it('should scale chart height according to browser zoom factor', () => {
-    spyOn(component.chart as ChartComponent, 'updateOptions');
-    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+  [0.5, 1, 2, 5].forEach(browserZoomFactor => {
+    it(`should scale chart height appropriately if the browser zoom factor is ${browserZoomFactor}`, () => {
+      spyOn(component.chart as ChartComponent, 'updateOptions');
+      spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(1500, 1000, 2000, 2);
+      component.onResize(1500, 1000, 2000, browserZoomFactor);
 
-    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: (1500 - estimatorBaseHeight - 200) * 2 },
+      expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+        chart: { height: (1500 - estimatorBaseHeight - 200) * browserZoomFactor },
+      });
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -65,30 +65,8 @@ describe('CarbonEstimationComponent', () => {
     expect(component.chartOptions.chart.height).toBe(600 - estimatorBaseHeight - 200 - 100);
   });
 
-  it('should recalculate chart height on window resize, for laptop screen', () => {
-    spyOn(component.chart as ChartComponent, 'updateOptions');
-    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
-
-    component.onResize(2000, 1000, 2000, 1);
-
-    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 1500 }, // Height will be capped at a percentage of the screen height
-    });
-  });
-
-  it('should recalculate chart height on window resize, for mobile screen', () => {
-    spyOn(component.chart as ChartComponent, 'updateOptions');
-    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
-
-    component.onResize(1000, 500, 1000, 1);
-
-    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 1000 - estimatorBaseHeight - 200 + estimatorHeights.title },
-    });
-  });
-
   [0.5, 1, 2, 5].forEach(browserZoomFactor => {
-    it(`should scale chart height appropriately if the browser zoom factor is ${browserZoomFactor}`, () => {
+    it(`should recalculate chart height on window resize, for laptop screen (zoom factor: ${browserZoomFactor})`, () => {
       spyOn(component.chart as ChartComponent, 'updateOptions');
       spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
@@ -97,6 +75,43 @@ describe('CarbonEstimationComponent', () => {
       expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
         chart: { height: (1500 - estimatorBaseHeight - 200) * browserZoomFactor },
       });
+    });
+  });
+
+  [0.5, 1, 2, 5].forEach(browserZoomFactor => {
+    it(`should recalculate chart height on window resize, for mobile screen (zoom factor: ${browserZoomFactor})`, () => {
+      spyOn(component.chart as ChartComponent, 'updateOptions');
+      spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+      component.onResize(1000, 500, 1000, browserZoomFactor);
+
+      expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+        chart: { height: (1000 - estimatorBaseHeight - 200 + estimatorHeights.title) * browserZoomFactor },
+      });
+    });
+  });
+
+  it('should cap chart height as a percentage of screen height for laptop screen', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    const screenHeight = 2000;
+    component.onResize(2000, 1000, screenHeight, 1);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: screenHeight * 0.75 },
+    });
+  });
+
+  it('should cap chart height as a percentage of screen height for mobile screen', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    const screenHeight = 1000;
+    component.onResize(1100, 500, screenHeight, 1);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: screenHeight * 0.75 },
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -59,6 +59,18 @@ describe('CarbonEstimationComponent', () => {
     expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200);
   });
 
+  it('should subtract the extraHeight input from the chart height on laptop screens', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+    fixture.componentRef.setInput('extraHeight', '100');
+
+    component.onResize(1500, 1000, 2000);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: 1500 - estimatorBaseHeight - 200 - 100 },
+    });
+  });
+
   it('should recalculate chart height on window resize, for laptop screen', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -65,53 +65,25 @@ describe('CarbonEstimationComponent', () => {
     expect(component.chartOptions.chart.height).toBe(600 - estimatorBaseHeight - 200 - 100);
   });
 
-  [0.5, 1, 2, 5].forEach(browserZoomFactor => {
-    it(`should recalculate chart height on window resize, for laptop screen (zoom factor: ${browserZoomFactor})`, () => {
-      spyOn(component.chart as ChartComponent, 'updateOptions');
-      spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
-
-      component.onResize(1500, 1000, 2000, browserZoomFactor);
-
-      expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-        chart: { height: (1500 - estimatorBaseHeight - 200) * browserZoomFactor },
-      });
-    });
-  });
-
-  [0.5, 1, 2, 5].forEach(browserZoomFactor => {
-    it(`should recalculate chart height on window resize, for mobile screen (zoom factor: ${browserZoomFactor})`, () => {
-      spyOn(component.chart as ChartComponent, 'updateOptions');
-      spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
-
-      component.onResize(1000, 500, 1000, browserZoomFactor);
-
-      expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-        chart: { height: (1000 - estimatorBaseHeight - 200 + estimatorHeights.title) * browserZoomFactor },
-      });
-    });
-  });
-
-  it('should cap chart height as a percentage of screen height for laptop screen', () => {
+  it('should recalculate chart height on window resize, for laptop screen', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    const screenHeight = 2000;
-    component.onResize(2000, 1000, screenHeight, 1);
+    component.onResize(2000, 1000, 2000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: screenHeight * 0.75 },
+      chart: { height: 1500 }, // Height will be capped at a percentage of the screen height
     });
   });
 
-  it('should cap chart height as a percentage of screen height for mobile screen', () => {
+  it('should recalculate chart height on window resize, for mobile screen', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    const screenHeight = 1000;
-    component.onResize(1100, 500, screenHeight, 1);
+    component.onResize(1000, 500, 1000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: screenHeight * 0.75 },
+      chart: { height: 1000 - estimatorBaseHeight - 200 + estimatorHeights.title },
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -54,7 +54,6 @@ describe('CarbonEstimationComponent', () => {
     component.ngOnInit();
     fixture.detectChanges();
 
-    console.log(`window.innerHeight: ${window.innerHeight}`);
     expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200);
   });
 
@@ -113,6 +112,17 @@ describe('CarbonEstimationComponent', () => {
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
       chart: { height: screenHeight * 0.75 },
+    });
+  });
+
+  it('should have a chart height of 300 for small innerHeight values (if screen height is large enough)', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    component.onResize(100, 1000, 2000);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: 300 },
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -69,10 +69,10 @@ describe('CarbonEstimationComponent', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(2000, 1000, 2000);
+    component.onResize(1500, 1000, 2000);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
-      chart: { height: 1500 }, // Height will be capped at a percentage of the screen height
+      chart: { height: 1500 - estimatorBaseHeight - 200 },
     });
   });
 
@@ -84,6 +84,30 @@ describe('CarbonEstimationComponent', () => {
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
       chart: { height: 1000 - estimatorBaseHeight - 200 + estimatorHeights.title },
+    });
+  });
+
+  it('should cap chart height as a percentage of screen height, for laptop screen', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    const screenHeight = 2000;
+    component.onResize(2000, 1000, screenHeight);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: screenHeight * 0.75 },
+    });
+  });
+
+  it('should cap chart height as a percentage of screen height, for mobile screen', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    const screenHeight = 1200;
+    component.onResize(1200, 500, screenHeight);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: screenHeight * 0.75 },
     });
   });
 

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -69,7 +69,7 @@ describe('CarbonEstimationComponent', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(2000, 1000, 2000);
+    component.onResize(2000, 1000, 2000, 1);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
       chart: { height: 1500 }, // Height will be capped at a percentage of the screen height
@@ -80,7 +80,7 @@ describe('CarbonEstimationComponent', () => {
     spyOn(component.chart as ChartComponent, 'updateOptions');
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
-    component.onResize(1000, 500, 1000);
+    component.onResize(1000, 500, 1000, 1);
 
     expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
       chart: { height: 1000 - estimatorBaseHeight - 200 + estimatorHeights.title },

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -47,31 +47,16 @@ describe('CarbonEstimationComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should set chart height when inner height is more than base height', () => {
-    console.log(`window.innerHeight: ${window.innerHeight}`);
+  it('should set the chart height when the component is initialised', () => {
     spyOnProperty(window, 'innerHeight').and.returnValue(1000);
+    spyOnProperty(window, 'innerWidth').and.returnValue(1000);
+    spyOnProperty(window.screen, 'height').and.returnValue(1080);
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
 
     component.ngOnInit();
     fixture.detectChanges();
-
-    console.log(`window.innerHeight: ${window.innerHeight}`);
-    console.log(`screen height: ${window.screen.height}`);
-    console.log(`device pixel ratio: ${window.devicePixelRatio}`);
 
     expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200);
-  });
-
-  it('should set chart height to value if inner height more than base height plus extra height', () => {
-    spyOnProperty(window, 'innerHeight').and.returnValue(1000);
-    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
-
-    fixture.componentRef.setInput('extraHeight', '100');
-    fixture.detectChanges();
-    component.ngOnInit();
-    fixture.detectChanges();
-
-    expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200 - 100);
   });
 
   it('should recalculate chart height on window resize, for laptop screen', () => {

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -119,17 +119,6 @@ describe('CarbonEstimationComponent', () => {
     expect(component.onResize).toHaveBeenCalledTimes(1);
   });
 
-  it('chart updateOptions should be not be called if inner height less than base height and extra height', () => {
-    spyOn(component.chart as ChartComponent, 'updateOptions');
-
-    fixture.componentRef.setInput('extraHeight', '600');
-    fixture.detectChanges();
-    component.ngOnInit();
-    fixture.detectChanges();
-
-    expect(component.chart?.updateOptions).not.toHaveBeenCalled();
-  });
-
   it('should set emissions with total % and category breakdown', () => {
     const expectedEmissions = [
       {

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -48,21 +48,26 @@ describe('CarbonEstimationComponent', () => {
   });
 
   it('should set chart height when inner height is more than base height', () => {
+    spyOnProperty(window, 'innerHeight').and.returnValue(1000);
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
     component.ngOnInit();
     fixture.detectChanges();
 
-    expect(component.chartOptions.chart.height).toBe(600 - estimatorBaseHeight - 200);
+    console.log(`window.innerHeight: ${window.innerHeight}`);
+    expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200);
   });
 
   it('should set chart height to value if inner height more than base height plus extra height', () => {
+    spyOnProperty(window, 'innerHeight').and.returnValue(1000);
     spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
     fixture.componentRef.setInput('extraHeight', '100');
     fixture.detectChanges();
     component.ngOnInit();
     fixture.detectChanges();
 
-    expect(component.chartOptions.chart.height).toBe(600 - estimatorBaseHeight - 200 - 100);
+    expect(component.chartOptions.chart.height).toBe(1000 - estimatorBaseHeight - 200 - 100);
   });
 
   it('should recalculate chart height on window resize, for laptop screen', () => {

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -87,6 +87,17 @@ describe('CarbonEstimationComponent', () => {
     });
   });
 
+  it('should scale chart height according to browser zoom factor', () => {
+    spyOn(component.chart as ChartComponent, 'updateOptions');
+    spyOnProperty(component.detailsPanel.nativeElement, 'clientHeight').and.returnValue(200);
+
+    component.onResize(1500, 1000, 2000, 2);
+
+    expect(component.chart?.updateOptions).toHaveBeenCalledOnceWith({
+      chart: { height: (1500 - estimatorBaseHeight - 200) * 2 },
+    });
+  });
+
   it('should call onResize when onExpansion is called', () => {
     spyOn(component, 'onResize');
 

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -136,16 +136,6 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   private getChartHeight(innerHeight: number, innerWidth: number, screenHeight: number): number {
     const expansionPanelHeight = this.detailsPanel.nativeElement.clientHeight;
 
-    const calculatedHeight = this.calculateChartHeight(innerHeight, innerWidth, expansionPanelHeight);
-
-    const maxScreenHeightRatio = 0.75;
-
-    // Cap chart height based on screen height to prevent issues with the chart
-    // becoming stretched when the component is displayed in a tall iFrame
-    return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
-  }
-
-  private calculateChartHeight(innerHeight: number, innerWidth: number, expansionPanelHeight: number) {
     // medium tailwind responsive design breakpoint https://tailwindcss.com/docs/responsive-design
     const responsiveBreakpoint = 768;
 
@@ -157,13 +147,18 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
         innerHeight - this.estimatorBaseHeight - expansionPanelHeight + estimatorHeights.title
       : innerHeight - this.estimatorBaseHeight - extraHeight - expansionPanelHeight;
 
-    // Cap on the mininum height of the chart to prevent the chart becoming squashed when zooming
-    // in on desktop browsers. (Zooming in results in window.innerHeight decreasing proportionally
-    // on most desktop browsers which can result in the calculatedHeight above becoming too small
-    // or even negative. N.B. Mobile browsers behave differently.)
+    // Bound smallest chart height to prevent it becoming squashed when zooming
+    // on desktop (zooming decreases innerHeight on most desktop browsers)
     const minChartHeight = 300;
 
-    return Math.max(calculatedHeight, minChartHeight);
+    // Cap chart height based on screen height to prevent issues with the chart
+    // becoming stretched when the component is displayed in a tall iFrame
+    const maxScreenHeightRatio = 0.75;
+
+    const heightBoundedAbove = Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
+    const heightBoundedAboveAndBelow = Math.max(heightBoundedAbove, minChartHeight);
+
+    return heightBoundedAboveAndBelow;
   }
 
   private getDataItem(key: string, value: number, parent: string): ApexChartDataItem {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -75,9 +75,7 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
   onResize(innerHeight: number, innerWidth: number, screenHeight: number): void {
     const chartHeight = this.getChartHeight(innerHeight, innerWidth, screenHeight);
-    if (chartHeight > 0) {
-      this.chart?.updateOptions({ chart: { height: chartHeight } });
-    }
+    this.chart?.updateOptions({ chart: { height: chartHeight } });
   }
 
   private getOverallEmissionPercentages(carbonEstimation: CarbonEstimation): ApexAxisChartSeries {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -54,14 +54,21 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): void {
-    const chartHeight = this.getChartHeight(window.innerHeight, window.innerWidth, window.screen.height);
+    const chartHeight = this.getChartHeight(
+      window.innerHeight,
+      window.innerWidth,
+      window.screen.height,
+      window.devicePixelRatio
+    );
     if (chartHeight > 0) {
       this.chartOptions.chart.height = chartHeight;
     }
 
     this.resizeSubscription = fromEvent(window, 'resize')
       .pipe(debounceTime(500))
-      .subscribe(() => this.onResize(window.innerHeight, window.innerWidth, window.screen.height));
+      .subscribe(() =>
+        this.onResize(window.innerHeight, window.innerWidth, window.screen.height, window.devicePixelRatio)
+      );
   }
 
   public ngOnDestroy(): void {
@@ -70,11 +77,11 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
   public onExpanded(): void {
     this.changeDetectorRef.detectChanges();
-    this.onResize(window.innerHeight, window.innerWidth, window.screen.height);
+    this.onResize(window.innerHeight, window.innerWidth, window.screen.height, window.devicePixelRatio);
   }
 
-  onResize(innerHeight: number, innerWidth: number, screenHeight: number): void {
-    const chartHeight = this.getChartHeight(innerHeight, innerWidth, screenHeight);
+  onResize(innerHeight: number, innerWidth: number, screenHeight: number, browserZoomFactor: number): void {
+    const chartHeight = this.getChartHeight(innerHeight, innerWidth, screenHeight, browserZoomFactor);
     if (chartHeight > 0) {
       this.chart?.updateOptions({ chart: { height: chartHeight } });
     }
@@ -135,7 +142,12 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
     );
   }
 
-  private getChartHeight(innerHeight: number, innerWidth: number, screenHeight: number): number {
+  private getChartHeight(
+    innerHeight: number,
+    innerWidth: number,
+    screenHeight: number,
+    browserZoomFactor: number // 1 = 100% zoom
+  ): number {
     const expansionPanelHeight = this.detailsPanel.nativeElement.clientHeight;
 
     const calculatedHeight = this.calculateChartHeight(innerHeight, innerWidth, expansionPanelHeight);
@@ -144,7 +156,7 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
     // Cap chart height based on screen height to prevent issues with the chart
     // becoming stretched when the component is displayed in a tall iFrame
-    return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio);
+    return Math.min(calculatedHeight, screenHeight * maxScreenHeightRatio) * browserZoomFactor;
   }
 
   private calculateChartHeight(innerHeight: number, innerWidth: number, expansionPanelHeight: number) {


### PR DESCRIPTION
[SFD-98 Jira ticket](https://scottlogic.atlassian.net/jira/software/projects/SFD/boards/104)

Scales the chart size with the browser zoom factor to fix a bug where the chart would become squashed when the browser zoom was increased.

Before fix:
![before-fix-500-percent-zoom](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/8a373d85-2cb3-48c7-a3c9-7a75b8105645)

After fix:
![after-fix-500-percent-zoom](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/9771d0ab-b767-4e71-bf50-360ce03d5580)

