### PR TITLE
SFD-115: Add reports for automated tests

### DIFF
--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -11,5 +11,10 @@ runs:
       run: npm run playwright-install
       shell: bash
     - name: Run Playwright tests
-      run: npm run playwright-test
+      run: npm run playwright-test -- --tracing=retain-on-failure
       shell: bash
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-traces
+        path: playwright/tests/test-results/

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -13,15 +13,11 @@ runs:
     - name: Run Playwright tests
       run: npm run playwright-test -- --tracing=retain-on-failure --html=reports/report.html
       shell: bash
-    - name: Upload traces
+    - name: Upload Playwright traces and report
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: playwright-traces
-        path: playwright/tests/test-results/
-    - name: Upload HTML report
-      uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-html-report
-        path: playwright/tests/reports
+        name: playwright-traces-and-report
+        path: |
+          playwright/tests/test-results/
+          playwright/tests/reports/

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -11,10 +11,17 @@ runs:
       run: npm run playwright-install
       shell: bash
     - name: Run Playwright tests
-      run: npm run playwright-test -- --tracing=retain-on-failure
+      run: npm run playwright-test -- --tracing=retain-on-failure --html=reports/report.html
       shell: bash
-    - uses: actions/upload-artifact@v4
+    - name: Upload traces
+      uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
         name: playwright-traces
         path: playwright/tests/test-results/
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-html-report
+        path: playwright/tests/reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ colorama==0.4.6
 greenlet==3.0.3
 idna==3.7
 iniconfig==2.0.0
+Jinja2==3.1.4
+MarkupSafe==2.1.5
 packaging==24.1
 playwright==1.44.0
 pluggy==1.5.0
@@ -11,6 +13,8 @@ psutil==5.9.8
 pyee==11.1.0
 pytest==8.2.2
 pytest-base-url==2.1.0
+pytest-html==4.1.1
+pytest-metadata==3.1.1
 pytest-playwright==0.5.0
 pytest-xprocess==1.0.2
 python-slugify==8.0.4


### PR DESCRIPTION
[SFD-115 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-115)

Adds artifact uploads in the playwright workflow for the traces and an HTML report file of the test results.

Notes:
WRT the unit tests, whilst Web Test Runner does support reporting, it seems that the experimental Angular builder which is the bridge between Angular and Web Test Runner doesn’t yet support this feature and there isn’t any documentation it so we may have to wait a bit to add reports for the unit tests.

On the Playwright front, I’ve added artifact uploads for the Playwright traces for failing tests and an HTML report using the pytest-html package which can be downloaded. @qgogay-scottlogic and @sdun-scottlogic are going to have a discussion about what sort of things we’d like to do with the test reporting (e.g. do we want to try to add a display to the GitHub UI?) and we can then investigate further in a follow up ticket.