### PR TITLE
SFD-123: Add assumptions view option before calculation

### DIFF
--- a/playwright/tests/test_17_EstTool_UI_AssumpLimitations.py
+++ b/playwright/tests/test_17_EstTool_UI_AssumpLimitations.py
@@ -62,8 +62,8 @@ def test_example(page: Page) -> None:
     expect(page.get_by_role("button", name="Assumptions and limitations")).to_be_visible()
     page.get_by_role("button", name="Assumptions and limitations").click()
     expect(page.get_by_role("heading", name="Assumptions and Limitations")).to_be_visible()
-    expect(page.get_by_label("Close assumptions and").filter(has_not_text=re.compile("Close"))).to_be_visible() # 'X' close button
-    # Need regex because has_text="Close" is case insensitive and 'X' button has the text 'close'
+    expect(page.get_by_label("Close assumptions and").filter(has_text=re.compile("close"))).to_be_visible() # 'X' close button
+    # Need regex because has_text="close" is case insensitive and other close button has the text 'Close'
     expect(page.get_by_text("The Technology Carbon Estimator tool is designed to")).to_be_visible()
     expect(page.get_by_role("heading", name="Assumptions", exact=True)).to_be_visible()
     expect(page.get_by_role("heading", name="Time period")).to_be_visible()

--- a/playwright/tests/test_17_EstTool_UI_AssumpLimitations.py
+++ b/playwright/tests/test_17_EstTool_UI_AssumpLimitations.py
@@ -62,7 +62,9 @@ def test_example(page: Page) -> None:
     expect(page.get_by_role("button", name="Assumptions and limitations")).to_be_visible()
     page.get_by_role("button", name="Assumptions and limitations").click()
     expect(page.get_by_role("heading", name="Assumptions and Limitations")).to_be_visible()
-    expect(page.get_by_text("The Technology Carbon")).to_be_visible()
+    expect(page.get_by_label("Close assumptions and").filter(has_not_text=re.compile("Close"))).to_be_visible() # 'X' close button
+    # Need regex because has_text="Close" is case insensitive and 'X' button has the text 'close'
+    expect(page.get_by_text("The Technology Carbon Estimator tool is designed to")).to_be_visible()
     expect(page.get_by_role("heading", name="Assumptions", exact=True)).to_be_visible()
     expect(page.get_by_role("heading", name="Time period")).to_be_visible()
     expect(page.get_by_text("The estimation is based on a")).to_be_visible()
@@ -96,7 +98,6 @@ def test_example(page: Page) -> None:
     expect(page.get_by_text("These figures are combined")).to_be_visible()
     expect(page.get_by_role("heading", name="Network Data Transfer")).to_be_visible()
     expect(page.get_by_text("Our outgoing network data")).to_be_visible()
-    expect(page.get_by_text("Assumptions and Limitations The Technology Carbon Estimator tool is designed to")).to_be_visible()
     page.get_by_role("heading", name="End-User Devices").click()
     expect(page.get_by_text("We combine device information")).to_be_visible()
     expect(page.get_by_role("heading", name="Limitations", exact=True)).to_be_visible()
@@ -113,8 +114,8 @@ def test_example(page: Page) -> None:
     expect(page.get_by_text("Like Off the shelf and open")).to_be_visible()
     expect(page.get_by_role("heading", name="Managed Services")).to_be_visible()
     expect(page.get_by_text("We currently do not make a")).to_be_visible()
-    expect(page.get_by_label("Close assumptions and")).to_be_visible()
-    page.get_by_label("Close assumptions and").click()
+    expect(page.get_by_label("Close assumptions and").filter(has_text=re.compile("Close"))).to_be_visible()
+    page.get_by_label("Close assumptions and").filter(has_text=re.compile("Close")).click()
     expect(page.get_by_role("heading", name="Technology Carbon Estimator")).to_be_visible()
     expect(page.get_by_role("heading", name="Organisation")).to_be_visible()
 

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -4,7 +4,7 @@
     <button
       type="button"
       class="material-icons-outlined tce-text hover:tce-bg-slate-200 hover:tce-rounded"
-      (click)="onClose()"
+      (click)="onClose(true, false)"
       aria-label="Close assumptions and limitations">
       close
     </button>
@@ -311,7 +311,7 @@
   </p>
   <button
     class="tce-button-close tce-px-3 tce-py-2 tce-self-end"
-    (click)="onClose()"
+    (click)="onClose(true, true)"
     aria-label="Close assumptions and limitations">
     Close
   </button>

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -1,5 +1,14 @@
 <div #assumptionsLimitation class="tce-flex tce-flex-col tce-gap-4" tabindex="0">
-  <h2 class="tce-text-2xl">Assumptions and Limitations</h2>
+  <div class="tce-flex tce-justify-between">
+    <h2 class="tce-text-2xl">Assumptions and Limitations</h2>
+    <button
+      type="button"
+      class="material-icons-outlined tce-text hover:tce-bg-slate-200 hover:tce-rounded"
+      (click)="onClose()"
+      aria-label="Close assumptions and limitations">
+      close
+    </button>
+  </div>
   <p class="tce-text-sm">
     The Technology Carbon Estimator tool is designed to give a high-level overview of the possible areas of carbon
     impact within your IT estate. We use a minimal number of questions to present this view, so we must make some

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -4,7 +4,7 @@
     <button
       type="button"
       class="material-icons-outlined tce-text hover:tce-bg-slate-200 hover:tce-rounded"
-      (click)="onClose(true, false)"
+      (click)="onClose()"
       aria-label="Close assumptions and limitations">
       close
     </button>
@@ -311,7 +311,7 @@
   </p>
   <button
     class="tce-button-close tce-px-3 tce-py-2 tce-self-end"
-    (click)="onClose(true, true)"
+    (click)="onClose()"
     aria-label="Close assumptions and limitations">
     Close
   </button>

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
@@ -40,24 +40,12 @@ describe('AssumptionsAndLimitationComponent', () => {
     expect(hasFocus).toBeTrue();
   });
 
-  it('should emit close event with true value when press esc key with focus within component', () => {
+  it('should emit close event with { true, true } value when press esc key with focus within component', () => {
     spyOn(component.closeEvent, 'emit');
 
     component.ngAfterContentInit();
     fixture.detectChanges();
 
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-
-    expect(component.closeEvent.emit).toHaveBeenCalledWith({ focusOpenButton: true, scrollToOpenButton: true });
-  });
-
-  it('should emit close event with false value when press esc key with focus not within component', () => {
-    spyOn(component.closeEvent, 'emit');
-
-    component.ngAfterContentInit();
-    fixture.detectChanges();
-    fixture.elementRef.nativeElement.focus();
-    fixture.detectChanges();
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(component.closeEvent.emit).toHaveBeenCalledWith({ focusOpenButton: true, scrollToOpenButton: true });

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AssumptionsAndLimitationComponent } from './assumptions-and-limitation.component';
-import { By } from '@angular/platform-browser';
 
 describe('AssumptionsAndLimitationComponent', () => {
   let component: AssumptionsAndLimitationComponent;
@@ -49,7 +48,7 @@ describe('AssumptionsAndLimitationComponent', () => {
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
-    expect(component.closeEvent.emit).toHaveBeenCalledWith(true);
+    expect(component.closeEvent.emit).toHaveBeenCalledWith({ focusOpenButton: true, scrollToOpenButton: true });
   });
 
   it('should emit close event with false value when press esc key with focus not within component', () => {
@@ -61,6 +60,6 @@ describe('AssumptionsAndLimitationComponent', () => {
     fixture.detectChanges();
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
-    expect(component.closeEvent.emit).toHaveBeenCalledWith(true);
+    expect(component.closeEvent.emit).toHaveBeenCalledWith({ focusOpenButton: true, scrollToOpenButton: true });
   });
 });

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.spec.ts
@@ -40,7 +40,7 @@ describe('AssumptionsAndLimitationComponent', () => {
     expect(hasFocus).toBeTrue();
   });
 
-  it('should emit close event with { true, true } value when press esc key with focus within component', () => {
+  it('should emit close event with true value when press esc key with focus within component', () => {
     spyOn(component.closeEvent, 'emit');
 
     component.ngAfterContentInit();
@@ -48,6 +48,6 @@ describe('AssumptionsAndLimitationComponent', () => {
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
-    expect(component.closeEvent.emit).toHaveBeenCalledWith({ focusOpenButton: true, scrollToOpenButton: true });
+    expect(component.closeEvent.emit).toHaveBeenCalledWith(true);
   });
 });

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -87,7 +87,7 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
   }
 
   public ngAfterContentInit(): void {
-    this.assumptionsLimitation.nativeElement.focus();
+    this.assumptionsLimitation.nativeElement.focus({ preventScroll: true });
   }
 
   public onClose(focusOpenButton: boolean, scrollToOpenButton: boolean): void {

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -25,11 +25,6 @@ const locationDescriptions: Record<WorldLocation, string> = {
   'LATIN AMERICA AND CARIBBEAN': 'Latin America and Caribbean',
 };
 
-export type AssumptionsLimitationCloseEvent = {
-  focusOpenButton: boolean;
-  scrollToOpenButton: boolean;
-};
-
 @Component({
   selector: 'assumptions-and-limitation',
   standalone: true,
@@ -37,7 +32,7 @@ export type AssumptionsLimitationCloseEvent = {
   imports: [DecimalPipe],
 })
 export class AssumptionsAndLimitationComponent implements AfterContentInit {
-  @Output() public closeEvent = new EventEmitter<AssumptionsLimitationCloseEvent>();
+  @Output() public closeEvent = new EventEmitter<boolean>();
   readonly ON_PREMISE_AVERAGE_PUE = ON_PREMISE_AVERAGE_PUE;
   readonly CLOUD_AVERAGE_PUE = CLOUD_AVERAGE_PUE;
   readonly siteTypeInfo = purposeOfSiteArray.map(purpose => ({
@@ -90,13 +85,13 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
     this.assumptionsLimitation.nativeElement.focus({ preventScroll: true });
   }
 
-  public onClose(focusOpenButton: boolean, scrollToOpenButton: boolean): void {
-    this.closeEvent.emit({ focusOpenButton, scrollToOpenButton });
+  public onClose(hasFocus = true): void {
+    this.closeEvent.emit(hasFocus);
   }
 
   @HostListener('document:keydown.escape', ['$event'])
   public onEscKeydown(): void {
     const hasFocus = this.assumptionsLimitation.nativeElement.contains(document.activeElement);
-    this.onClose(hasFocus, hasFocus);
+    this.onClose(hasFocus);
   }
 }

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -25,6 +25,11 @@ const locationDescriptions: Record<WorldLocation, string> = {
   'LATIN AMERICA AND CARIBBEAN': 'Latin America and Caribbean',
 };
 
+export type AssumptionsLimitationCloseEvent = {
+  focusOpenButton: boolean;
+  scrollToOpenButton: boolean;
+};
+
 @Component({
   selector: 'assumptions-and-limitation',
   standalone: true,
@@ -32,7 +37,7 @@ const locationDescriptions: Record<WorldLocation, string> = {
   imports: [DecimalPipe],
 })
 export class AssumptionsAndLimitationComponent implements AfterContentInit {
-  @Output() public closeEvent = new EventEmitter<boolean>();
+  @Output() public closeEvent = new EventEmitter<AssumptionsLimitationCloseEvent>();
   readonly ON_PREMISE_AVERAGE_PUE = ON_PREMISE_AVERAGE_PUE;
   readonly CLOUD_AVERAGE_PUE = CLOUD_AVERAGE_PUE;
   readonly siteTypeInfo = purposeOfSiteArray.map(purpose => ({
@@ -85,13 +90,13 @@ export class AssumptionsAndLimitationComponent implements AfterContentInit {
     this.assumptionsLimitation.nativeElement.focus();
   }
 
-  public onClose(hasFocus = true): void {
-    this.closeEvent.emit(hasFocus);
+  public onClose(focusOpenButton: boolean, scrollToOpenButton: boolean): void {
+    this.closeEvent.emit({ focusOpenButton, scrollToOpenButton });
   }
 
   @HostListener('document:keydown.escape', ['$event'])
   public onEscKeydown(): void {
     const hasFocus = this.assumptionsLimitation.nativeElement.contains(document.activeElement);
-    this.onClose(hasFocus);
+    this.onClose(hasFocus, hasFocus);
   }
 }

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -11,6 +11,7 @@
       } @else {
         <div class="tce-flex tce-justify-end tce-pb-4 -tce-mt-2">
           <button
+            #showAssumptionsLimitationButton
             class="tce-button-assumptions tce-px-3 tce-w-fit tce-self-end"
             (click)="showAssumptionsAndLimitation()">
             Assumptions and limitations

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -12,7 +12,7 @@
         <div class="tce-flex tce-justify-end tce-pb-4 -tce-mt-2">
           <button
             #showAssumptionsLimitationButton
-            class="tce-button-assumptions tce-px-3 tce-w-fit tce-self-end"
+            class="tce-button-assumptions tce-px-3 tce-py-2 tce-w-fit tce-self-end"
             (click)="showAssumptionsAndLimitation()">
             Assumptions and limitations
           </button>

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -27,14 +27,6 @@
         #estimations
         class="tce-w-full md:tce-w-1/2 tce-flex tce-flex-col tce-h-dvh md:tce-h-fit tce-py-4 md:tce-py-0 md:tce-pl-4 md:tce-sticky md:tce-top-0">
         <carbon-estimation [carbonEstimation]="carbonEstimation" [extraHeight]="extraHeight"></carbon-estimation>
-        @if (!showAssumptionsAndLimitationView) {
-          <button
-            id="showAssumptionsAndLimitationButton"
-            class="tce-button-assumptions tce-px-3 tce-py-2 tce-w-fit tce-self-end"
-            (click)="showAssumptionsAndLimitation()">
-            Assumptions and limitations
-          </button>
-        }
       </div>
     }
   </div>

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -9,6 +9,13 @@
           aria-live="polite"
           (closeEvent)="closeAssumptionsAndLimitation($event)"></assumptions-and-limitation>
       } @else {
+        <div class="tce-flex tce-justify-end tce-pb-4 -tce-mt-2">
+          <button
+            class="tce-button-assumptions tce-px-3 tce-w-fit tce-self-end"
+            (click)="showAssumptionsAndLimitation()">
+            Assumptions and limitations
+          </button>
+        </div>
         <carbon-estimator-form
           [formValue]="formValue"
           (formSubmit)="handleFormSubmit($event)"

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
@@ -103,42 +103,15 @@ describe('TechCarbonEstimatorComponent', () => {
     expect(component.showEstimation).toBeFalse();
   });
 
-  it('should scroll to top of assumptions and limitation when showAssumptionsAndLimitation is called', () => {
-    component.showEstimation = true;
-    component.showAssumptionsAndLimitationView = true;
-    fixture.detectChanges();
-    spyOn(component.assumptionsLimitation.nativeElement, 'scrollIntoView').and.callThrough();
-    component.showAssumptionsAndLimitation();
-    fixture.detectChanges();
-
-    expect(component.assumptionsLimitation.nativeElement.scrollIntoView).toHaveBeenCalled();
-  });
-
-  it('should scroll to top of estimations when closeAssumptionsAndLimitation is called', () => {
-    component.showEstimation = true;
-    // Setting to true so the component exists, the detectChanges on line 48 doesn't not seem to result in the component being created as is normal when running the app
+  it('should focus on assumptions button when closeAssumptionsAndLimitation is called with focusOpenButton true', () => {
     component.showAssumptionsAndLimitationView = true;
     fixture.detectChanges();
 
-    spyOn(component.estimations.nativeElement, 'scrollIntoView').and.callThrough();
-
-    component.closeAssumptionsAndLimitation(false);
+    component.closeAssumptionsAndLimitation({ focusOpenButton: true, scrollToOpenButton: true });
     fixture.detectChanges();
 
-    expect(component.estimations.nativeElement.scrollIntoView).toHaveBeenCalled();
-  });
-
-  it('should focus on assumptions button when closeAssumptionsAndLimitation is called with hasFocus true', () => {
-    component.showEstimation = true;
-    component.showAssumptionsAndLimitationView = true;
-    fixture.detectChanges();
-
-    component.closeAssumptionsAndLimitation(true);
-    fixture.detectChanges();
-
-    const button = fixture.nativeElement
-      .querySelector('button#showAssumptionsAndLimitationButton')
-      ?.contains(document.activeElement);
-    expect(button).toBeTrue();
+    const button = component.showAssumptionsLimitationButton.nativeElement;
+    expect(document.activeElement).toEqual(button);
+    expect(button);
   });
 });

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
@@ -103,11 +103,11 @@ describe('TechCarbonEstimatorComponent', () => {
     expect(component.showEstimation).toBeFalse();
   });
 
-  it('should focus on assumptions button when closeAssumptionsAndLimitation is called with focusOpenButton true', () => {
+  it('should focus on assumptions button when closeAssumptionsAndLimitation is called with hasFocus true', () => {
     component.showAssumptionsAndLimitationView = true;
     fixture.detectChanges();
 
-    component.closeAssumptionsAndLimitation({ focusOpenButton: true, scrollToOpenButton: true });
+    component.closeAssumptionsAndLimitation(true);
     fixture.detectChanges();
 
     const button = component.showAssumptionsLimitationButton.nativeElement;

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
@@ -55,8 +55,6 @@ export class TechCarbonEstimatorComponent {
 
   public showAssumptionsAndLimitation(): void {
     this.showAssumptionsAndLimitationView = true;
-    this.changeDetector.detectChanges();
-    this.assumptionsLimitation.nativeElement.scrollIntoView();
   }
 
   public closeAssumptionsAndLimitation(event: AssumptionsLimitationCloseEvent): void {

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
@@ -5,10 +5,7 @@ import { CarbonEstimation, EstimatorValues } from '../types/carbon-estimator';
 import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import {
-  AssumptionsAndLimitationComponent,
-  AssumptionsLimitationCloseEvent,
-} from '../assumptions-and-limitation/assumptions-and-limitation.component';
+import { AssumptionsAndLimitationComponent } from '../assumptions-and-limitation/assumptions-and-limitation.component';
 import { DisclaimerComponent } from '../disclaimer/disclaimer.component';
 
 @Component({
@@ -57,15 +54,12 @@ export class TechCarbonEstimatorComponent {
     this.showAssumptionsAndLimitationView = true;
   }
 
-  public closeAssumptionsAndLimitation(event: AssumptionsLimitationCloseEvent): void {
+  public closeAssumptionsAndLimitation(hasFocus: boolean): void {
     this.showAssumptionsAndLimitationView = false;
     this.changeDetector.detectChanges();
     const openButton = this.showAssumptionsLimitationButton.nativeElement;
-    if (event.focusOpenButton) {
+    if (hasFocus) {
       openButton.focus();
-    }
-    if (event.scrollToOpenButton) {
-      openButton.scrollIntoView();
     }
   }
 }

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
@@ -5,7 +5,10 @@ import { CarbonEstimation, EstimatorValues } from '../types/carbon-estimator';
 import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { AssumptionsAndLimitationComponent } from '../assumptions-and-limitation/assumptions-and-limitation.component';
+import {
+  AssumptionsAndLimitationComponent,
+  AssumptionsLimitationCloseEvent,
+} from '../assumptions-and-limitation/assumptions-and-limitation.component';
 import { DisclaimerComponent } from '../disclaimer/disclaimer.component';
 
 @Component({
@@ -31,6 +34,7 @@ export class TechCarbonEstimatorComponent {
 
   @ViewChild('assumptionsLimitation', { read: ElementRef }) assumptionsLimitation!: ElementRef;
   @ViewChild('estimations') estimations!: ElementRef;
+  @ViewChild('showAssumptionsLimitationButton') showAssumptionsLimitationButton!: ElementRef<HTMLButtonElement>;
 
   constructor(
     private estimationService: CarbonEstimationService,
@@ -55,12 +59,15 @@ export class TechCarbonEstimatorComponent {
     this.assumptionsLimitation.nativeElement.scrollIntoView();
   }
 
-  public closeAssumptionsAndLimitation(hasFocus: boolean): void {
+  public closeAssumptionsAndLimitation(event: AssumptionsLimitationCloseEvent): void {
     this.showAssumptionsAndLimitationView = false;
-    this.estimations.nativeElement.scrollIntoView();
-    if (hasFocus) {
-      this.changeDetector.detectChanges();
-      this.estimations.nativeElement.querySelector('button#showAssumptionsAndLimitationButton')?.focus();
+    this.changeDetector.detectChanges();
+    const openButton = this.showAssumptionsLimitationButton.nativeElement;
+    if (event.focusOpenButton) {
+      openButton.focus();
+    }
+    if (event.scrollToOpenButton) {
+      openButton.scrollIntoView();
     }
   }
 }


### PR DESCRIPTION
[SFD-123 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-123)

Moves the button to open the assumptions and limitations view to the estimator form below the disclaimer section.

![new-button-position](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/110816538/1e9f569b-a9f1-47a6-aa2a-acafa1165fb9)

Notes:
- When closing the assumptions and limitations view, the open button is scrolled into view expect when pressing escape when the view does not have focus in which case the old behaviour was retained.
