### PR TITLE
SFD-136 Set up workflow to publish npm package

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy estimator Pages
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  release:
+    types: [published]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,7 @@
 name: Publish new package
 on:
   workflow_dispatch:
+  pull_request:
 env:
   PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
 concurrency:
@@ -61,7 +62,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
-          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public
+          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public --dry-run
 
   release:
     runs-on: ubuntu-latest
@@ -85,4 +86,5 @@ jobs:
               ${PACKAGE_PREFIX}${VERSION}.tgz \
               --repo="$GITHUB_REPOSITORY" \
               --prerelease \
+              --draft \
               --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,26 @@
+name: Publish new package
+on:
+  workflow_dispatch:
+  pull_request: #TODO - For testing, remove before final merge
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/actions/set-up-environment
+      - name: Create package
+        run: |
+          npm run prepare
+          cp README.md package.json ./dist/tech-carbon-estimator/
+          cd dist/tech-carbon-estimator
+          npm pkg delete scripts private devDependencies files
+          npm pkg set main=main.js
+          npm pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          path: scottlogic-tech-carbon-estimator-*.tgz
+          overwrite: true #TODO - For testing, remove before final merge

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,6 +7,8 @@ env:
 jobs:
   package:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.output.outputs.version}}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -29,10 +31,15 @@ jobs:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
           path: ./dist/tech-carbon-estimator/${{env.PACKAGE_PREFIX}}${{env.VERSION}}.tgz
           overwrite: true #TODO - For testing, remove before final merge
+      - name: Output version
+        id: output
+        run: echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   publish:
     runs-on: ubuntu-latest
     needs: package
+    env:
+      VERSION: ${{needs.package.outputs.version}}
     steps:
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,6 +2,8 @@ name: Publish new package
 on:
   workflow_dispatch:
   pull_request: #TODO - For testing, remove before final merge
+env:
+  PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -24,6 +26,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: scottlogic-tech-carbon-estimator-${{env.VERSION}}
-          path: ./dist/tech-carbon-estimator/scottlogic-tech-carbon-estimator-${{env.VERSION}}.tgz
+          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
+          path: ./dist/tech-carbon-estimator/${{env.PACKAGE_PREFIX}}${{env.VERSION}}.tgz
           overwrite: true #TODO - For testing, remove before final merge

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -40,6 +40,8 @@ jobs:
     needs: package
     env:
       VERSION: ${{needs.package.outputs.version}}
+    permissions:
+      id-token: write
     steps:
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,10 +45,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+          registry-url: 'https://registry.npmjs.org'
       - name: Download package
         uses: actions/download-artifact@v4
         with:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
       - name: Publish to NPM registry
+        env:
+          NPM_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
-          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --access public
+          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,7 +1,6 @@
 name: Publish new package
 on:
   workflow_dispatch:
-  pull_request:
 env:
   PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
 concurrency:
@@ -62,7 +61,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
-          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public --dry-run
+          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public
 
   release:
     runs-on: ubuntu-latest
@@ -86,5 +85,4 @@ jobs:
               ${PACKAGE_PREFIX}${VERSION}.tgz \
               --repo="$GITHUB_REPOSITORY" \
               --prerelease \
-              --draft \
               --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -77,5 +77,5 @@ jobs:
           gh release create "v${VERSION}" \
               ${PACKAGE_PREFIX}${VERSION}.tgz \
               --draft \
-              --pre-release \
+              --prerelease \
               --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,9 +18,12 @@ jobs:
           npm pkg delete scripts private devDependencies files
           npm pkg set main=main.js
           npm pack
+          VERSION=$(npm pkg get version --workspaces=false | tr -d \")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          path: ./dist/tech-carbon-estimator/scottlogic-tech-carbon-estimator-*.tgz
+          name: scottlogic-tech-carbon-estimator-${{env.VERSION}}
+          path: ./dist/tech-carbon-estimator/scottlogic-tech-carbon-estimator-${{env.VERSION}}.tgz
           overwrite: true #TODO - For testing, remove before final merge

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,6 +4,9 @@ on:
   pull_request: #TODO - For testing, remove before final merge
 env:
   PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
+concurrency:
+  group: 'publish'
+  cancel-in-progress: false
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -57,3 +57,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public
+
+  release:
+    runs-on: ubuntu-latest
+    needs: 
+      - package
+      #- publish #TODO - include once publish passes
+    env:
+      VERSION: ${{needs.package.outputs.version}}
+    permissions:
+      contents: write
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
+      - name: Create Github Release
+        run: |
+          gh release create "v${VERSION}" \
+              ${PACKAGE_PREFIX}${VERSION}.tgz \
+              --draft \
+              --pre-release \
+              --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,7 +1,6 @@
 name: Publish new package
 on:
   workflow_dispatch:
-  pull_request: #TODO - For testing, remove before final merge
 env:
   PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
 concurrency:
@@ -33,7 +32,6 @@ jobs:
           if-no-files-found: error
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
           path: ./dist/tech-carbon-estimator/${{env.PACKAGE_PREFIX}}${{env.VERSION}}.tgz
-          overwrite: true #TODO - For testing, remove before final merge
       - name: Output version
         id: output
         run: echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -65,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - package
-      #- publish #TODO - include once publish passes
+      - publish
     env:
       VERSION: ${{needs.package.outputs.version}}
     permissions:
@@ -82,6 +80,5 @@ jobs:
           gh release create "v${VERSION}" \
               ${PACKAGE_PREFIX}${VERSION}.tgz \
               --repo="$GITHUB_REPOSITORY" \
-              --draft \
               --prerelease \
               --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -54,6 +54,6 @@ jobs:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
       - name: Publish to NPM registry
         env:
-          NPM_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,8 +7,12 @@ concurrency:
   group: 'publish'
   cancel-in-progress: false
 jobs:
+  test:
+    uses: ./.github/workflows/pull-request.yml
+
   package:
     runs-on: ubuntu-latest
+    needs: test
     outputs:
       version: ${{ steps.output.outputs.version}}
     steps:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,3 +29,19 @@ jobs:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
           path: ./dist/tech-carbon-estimator/${{env.PACKAGE_PREFIX}}${{env.VERSION}}.tgz
           overwrite: true #TODO - For testing, remove before final merge
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
+      - name: Publish to NPM registry
+        run: |
+          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --access public --dry-run

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -51,4 +51,4 @@ jobs:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
       - name: Publish to NPM registry
         run: |
-          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --access public --dry-run
+          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --access public

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,5 +22,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          path: scottlogic-tech-carbon-estimator-*.tgz
+          path: ./dist/tech-carbon-estimator/scottlogic-tech-carbon-estimator-*.tgz
           overwrite: true #TODO - For testing, remove before final merge

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           gh release create "v${VERSION}" \
               ${PACKAGE_PREFIX}${VERSION}.tgz \
+              --repo="$GITHUB_REPOSITORY" \
               --draft \
               --prerelease \
               --generate-notes

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
       - name: Create Github Release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "v${VERSION}" \
               ${PACKAGE_PREFIX}${VERSION}.tgz \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: PR Workflow
 on:
   - pull_request
   - workflow_dispatch
+  - workflow_call
 
 jobs:
   build:

--- a/playwright/tests/test_0_TrialTest_HappyPath.py
+++ b/playwright/tests/test_0_TrialTest_HappyPath.py
@@ -10,7 +10,7 @@ def test_example(page: Page) -> None:
 
     # page.pause()
     expect(page.get_by_role("heading", name="Carbon Estimator")).to_be_visible()
-    expect(page.get_by_label("How many employees are in the")).to_have_value("100");
+    expect(page.get_by_label("How many employees are in the")).to_have_value("1000");
     expect(page.get_by_text("Desktops 50%")).to_be_visible()
     page.get_by_text("Laptops 50%").click()
     expect(page.get_by_role("heading", name="On-Premise Servers")).to_be_visible()

--- a/playwright/tests/test_0_TrialTest_HappyPath.py
+++ b/playwright/tests/test_0_TrialTest_HappyPath.py
@@ -10,7 +10,7 @@ def test_example(page: Page) -> None:
 
     # page.pause()
     expect(page.get_by_role("heading", name="Carbon Estimator")).to_be_visible()
-    expect(page.get_by_label("How many employees are in the")).to_have_value("1000");
+    expect(page.get_by_label("How many employees are in the")).to_have_value("100");
     expect(page.get_by_text("Desktops 50%")).to_be_visible()
     page.get_by_text("Laptops 50%").click()
     expect(page.get_by_role("heading", name="On-Premise Servers")).to_be_visible()


### PR DESCRIPTION
Final process should be:
- Run tests
- Build package and upload as artifact
- Use artifact to publish to npm
- Use artifact and version tag to create release

It's not enforced but the intention is that you run the workflow manually using the corresponding tag/commit for the version.

Also updated the pages workflow so that it is triggered when a new release is created.

Tested as far as possible to ensure that npm publish is authenticated and draft release is created but need to run from main with an updated version for it to complete fully.