### PR TITLE
SFD-136 Publish pages after successful release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,7 @@ name: Deploy estimator Pages
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_call:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -86,3 +86,6 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --prerelease \
               --generate-notes
+
+  publish_pages:
+    uses: ./.github/workflows/pages.yml

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,14 +7,43 @@ concurrency:
   group: 'publish'
   cancel-in-progress: false
 jobs:
+  check_version:
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.output.outputs.package_name}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Check that package version and tag align
+        run: |
+          VERSION=$(npm pkg get version --workspaces=false | tr -d \")
+          if [ ${GITHUB_REF_NAME} == v${VERSION} ]
+          then
+            echo "PACKAGE_NAME=${PACKAGE_PREFIX}${VERSION}" >> $GITHUB_ENV
+          else
+            echo "Workflow must be run from tag that matches package version."
+            echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}, PACKAGE_VERSION=v${VERSION}"
+            exit 1
+          fi
+      - name: Output package name
+        id: output
+        run: echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: check_version
     uses: ./.github/workflows/pull-request.yml
 
   package:
     runs-on: ubuntu-latest
-    needs: test
-    outputs:
-      version: ${{ steps.output.outputs.version}}
+    needs:
+      - check_version
+      - test
+    env:
+      PACKAGE_NAME: ${{needs.check_version.outputs.package_name}}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -28,23 +57,20 @@ jobs:
           npm pkg delete scripts private devDependencies files
           npm pkg set main=main.js
           npm pack
-          VERSION=$(npm pkg get version --workspaces=false | tr -d \")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
-          path: ./dist/tech-carbon-estimator/${{env.PACKAGE_PREFIX}}${{env.VERSION}}.tgz
-      - name: Output version
-        id: output
-        run: echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          name: ${{env.PACKAGE_NAME}}
+          path: ./dist/tech-carbon-estimator/${{env.PACKAGE_NAME}}.tgz
 
   publish:
     runs-on: ubuntu-latest
-    needs: package
+    needs:
+      - check_version
+      - package
     env:
-      VERSION: ${{needs.package.outputs.version}}
+      PACKAGE_NAME: ${{needs.check_version.outputs.package_name}}
     permissions:
       id-token: write
     steps:
@@ -56,35 +82,37 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
+          name: ${{env.PACKAGE_NAME}}
       - name: Publish to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
-          npm publish ${PACKAGE_PREFIX}${VERSION}.tgz --provenance --access public
+          npm publish ${PACKAGE_NAME}.tgz --provenance --access public
 
   release:
     runs-on: ubuntu-latest
     needs: 
+      - check_version
       - package
       - publish
     env:
-      VERSION: ${{needs.package.outputs.version}}
+      PACKAGE_NAME: ${{needs.check_version.outputs.package_name}}
     permissions:
       contents: write
     steps:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: ${{env.PACKAGE_PREFIX}}${{env.VERSION}}
+          name: ${{env.PACKAGE_NAME}}
       - name: Create Github Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${VERSION}" \
-              ${PACKAGE_PREFIX}${VERSION}.tgz \
+          gh release create "${GITHUB_REF_NAME}" \
+              ${PACKAGE_NAME}.tgz \
               --repo="$GITHUB_REPOSITORY" \
               --prerelease \
+              --verify-tag \
               --generate-notes
 
   publish_pages:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,7 @@
 name: Publish new package
 on:
   workflow_dispatch:
+  pull_request:
 env:
   PACKAGE_PREFIX: scottlogic-tech-carbon-estimator-
 concurrency:


### PR DESCRIPTION
- Allow pages workflow to be called from other workflows
- Restrict publish workflow so that it must be triggered from a matching tag
- Tidy up package name environment variables