### PR TITLE
SFD-141 Diagram can overlap TCS footer when zoomed in

### DIFF
--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -18,7 +18,7 @@
     @if (showEstimation) {
       <div
         #estimations
-        class="tce-w-full md:tce-w-1/2 tce-flex tce-flex-col tce-h-dvh md:tce-h-fit tce-py-4 md:tce-py-0 md:tce-pl-4 md:tce-sticky md:tce-top-0">
+        class="tce-w-full md:tce-w-1/2 tce-flex tce-flex-col tce-h-fit tce-py-4 md:tce-py-0 md:tce-pl-4 md:tce-sticky md:tce-top-0">
         <carbon-estimation [carbonEstimation]="carbonEstimation" [extraHeight]="extraHeight"></carbon-estimation>
         @if (!showAssumptionsAndLimitationView) {
           <button

--- a/src/package-index.html
+++ b/src/package-index.html
@@ -7,10 +7,11 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet" />
   </head>
-  <body class="dark:tce-bg-slate-800 dark:tce-text-slate-50">
+  <body class="tce-m-0 dark:tce-bg-slate-800 dark:tce-text-slate-50">
     <noscript
       >Javascript appears to be disabled - unfortunately the estimator requires it to be enabled to function.</noscript
     >
     <tech-carbon-estimator></tech-carbon-estimator>
+    <footer class="tce-p-5 tce-bg-slate-800 tce-text-slate-50 dark:tce-bg-slate-950">© Copyright Scott Logic</footer>
   </body>
 </html>


### PR DESCRIPTION
- Added a footer to package-index.html for ease of testing
  - Run with `ng serve --configuration npm-package` to use this version
- Removed dynamic viewport height to prevent parent being smaller than its children when zoomed in

### Before:
![image](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/117279304/367f0893-81d0-4a7c-93c9-d3f79e420f6f)
### After:
![image](https://github.com/ScottLogic/sl-tech-carbon-estimator/assets/117279304/9e9f6030-99f1-46f5-b183-4cfc43997229)
