### PR TITLE
SFD-143: Make dark mode error text easier to read

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -14,7 +14,7 @@
           required
           [attr.aria-describedby]="(headCount | invalidated) ? 'headCountError' : null" />
         @if (headCount | invalidated) {
-          <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="headCountError">
+          <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="headCountError">
             <span class="material-icons-outlined">error</span>
             <p>The number of employees must be greater than 0.</p>
           </div>
@@ -81,7 +81,7 @@
           required
           [attr.aria-describedby]="(numberOfServers | invalidated) ? 'numberOfServersError' : null" />
         @if (numberOfServers | invalidated) {
-          <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
+          <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
             <span class="material-icons-outlined">error</span>
             <p>The number of servers must be greater than or equal to 0.</p>
           </div>
@@ -210,7 +210,7 @@
             required
             [attr.aria-describedby]="(monthlyActiveUsers | invalidated) ? 'monthlyActiveUsersError' : null" />
           @if (monthlyActiveUsers | invalidated) {
-            <div class="tce-text-error-red tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
+            <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>
                 Monthly active users must be greater than 0. To specify no external users, use the
@@ -269,7 +269,7 @@
     </div>
     @if (estimatorForm | invalidated) {
       <div
-        class="tce-text-error-red tce-flex tce-gap-1 tce-justify-end tce-mt-2"
+        class="tce-error-text tce-flex tce-gap-1 tce-justify-end tce-mt-2"
         aria-live="polite"
         id="calculateDisabledMessage">
         <span class="material-icons-outlined">error</span>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -14,7 +14,7 @@
           required
           [attr.aria-describedby]="(headCount | invalidated) ? 'headCountError' : null" />
         @if (headCount | invalidated) {
-          <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="headCountError">
+          <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="headCountError">
             <span class="material-icons-outlined">error</span>
             <p>The number of employees must be greater than 0.</p>
           </div>
@@ -81,7 +81,7 @@
           required
           [attr.aria-describedby]="(numberOfServers | invalidated) ? 'numberOfServersError' : null" />
         @if (numberOfServers | invalidated) {
-          <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
+          <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
             <span class="material-icons-outlined">error</span>
             <p>The number of servers must be greater than or equal to 0.</p>
           </div>
@@ -210,7 +210,7 @@
             required
             [attr.aria-describedby]="(monthlyActiveUsers | invalidated) ? 'monthlyActiveUsersError' : null" />
           @if (monthlyActiveUsers | invalidated) {
-            <div class="tce-error-text tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
+            <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>
                 Monthly active users must be greater than 0. To specify no external users, use the
@@ -269,7 +269,7 @@
     </div>
     @if (estimatorForm | invalidated) {
       <div
-        class="tce-error-text tce-flex tce-gap-1 tce-justify-end tce-mt-2"
+        class="tce-error-box tce-flex tce-gap-1 tce-justify-end tce-mt-2"
         aria-live="polite"
         id="calculateDisabledMessage">
         <span class="material-icons-outlined">error</span>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -24,7 +24,6 @@ const locationDescriptions: Record<WorldLocation, string> = {
   selector: 'carbon-estimator-form',
   standalone: true,
   templateUrl: './carbon-estimator-form.component.html',
-  styles: ['input.ng-touched.ng-invalid { border-color: theme("colors.error-red"); }'],
   imports: [
     ReactiveFormsModule,
     FormsModule,

--- a/src/package-styles.css
+++ b/src/package-styles.css
@@ -1,10 +1,10 @@
-input, select {
-  @apply dark:tce-text-slate-600
-}
-
 @media (prefers-color-scheme: dark) {
   .apexcharts-legend-text {
     @apply !tce-text-slate-50
+  }
+
+  input, select {
+    @apply tce-text-slate-600
   }
 
   input.ng-invalid.ng-touched {

--- a/src/package-styles.css
+++ b/src/package-styles.css
@@ -6,4 +6,12 @@ input, select {
   .apexcharts-legend-text {
     @apply !tce-text-slate-50
   }
+
+  input.ng-invalid.ng-touched {
+    @apply tce-border-red-700
+  }
+
+  .tce-error-box {
+    @apply tce-text-white tce-bg-red-700 tce-p-1 tce-rounded tce-border tce-border-white
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 input.ng-invalid.ng-touched {
-  @apply tce-border-red-600 dark:tce-border-red-700 tce-border-2 tce-m-[-1px]
+  @apply tce-border-red-600 tce-border-2 tce-m-[-1px]
 }
 
 .tce-error-box {
-  @apply tce-text-red-600 dark:tce-text-white dark:tce-bg-red-700 dark:tce-p-1 dark:tce-rounded dark:tce-border dark:tce-border-white
+  @apply tce-text-red-600
 }
 
 .tce-note {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 input.ng-invalid.ng-touched {
-  @apply tce-border-error-red dark:tce-border-error-orange
+  @apply tce-border-error-red tce-border-2 tce-m-[-1px]
 }
 
-.tce-error-text {
-  @apply tce-text-error-red dark:tce-text-error-orange
+.tce-error-box {
+  @apply tce-text-white tce-bg-error-red tce-p-1 tce-rounded dark:tce-border dark:tce-border-white
 }
 
 .tce-note {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 input.ng-invalid.ng-touched {
-  @apply tce-border-error-red tce-border-2 tce-m-[-1px]
+  @apply tce-border-red-600 dark:tce-border-red-700 tce-border-2 tce-m-[-1px]
 }
 
 .tce-error-box {
-  @apply tce-text-white tce-bg-error-red tce-p-1 tce-rounded dark:tce-border dark:tce-border-white
+  @apply tce-text-red-600 dark:tce-text-white dark:tce-bg-red-700 dark:tce-p-1 dark:tce-rounded dark:tce-border dark:tce-border-white
 }
 
 .tce-note {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+input.ng-invalid.ng-touched {
+  @apply tce-border-error-red
+}
+
 .tce-note {
   @apply tce-bg-sky-200 tce-border-sky-400 tce-text-slate-800
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,11 @@
 @tailwind utilities;
 
 input.ng-invalid.ng-touched {
-  @apply tce-border-error-red
+  @apply tce-border-error-red dark:tce-border-error-orange
+}
+
+.tce-error-text {
+  @apply tce-text-error-red dark:tce-text-error-orange
 }
 
 .tce-note {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 import { isolateInsideOfContainer, scopedPreflightStyles } from 'tailwindcss-scoped-preflight';
 import form from '@tailwindcss/forms';
-import { red } from 'tailwindcss/colors';
+import { red, orange } from 'tailwindcss/colors';
 
 export default {
   content: ['./src/**/*.{html,ts}'],
@@ -11,6 +11,7 @@ export default {
       },
       colors: {
         'error-red': red['600'],
+        'error-orange': orange['400'],
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 import { isolateInsideOfContainer, scopedPreflightStyles } from 'tailwindcss-scoped-preflight';
 import form from '@tailwindcss/forms';
-import { red, orange } from 'tailwindcss/colors';
+import { red } from 'tailwindcss/colors';
 
 export default {
   content: ['./src/**/*.{html,ts}'],
@@ -10,8 +10,7 @@ export default {
         sans: ['objektiv-mk1', 'sans-serif'],
       },
       colors: {
-        'error-red': red['600'],
-        'error-orange': orange['400'],
+        'error-red': red['700'],
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,5 @@
 import { isolateInsideOfContainer, scopedPreflightStyles } from 'tailwindcss-scoped-preflight';
 import form from '@tailwindcss/forms';
-import { red } from 'tailwindcss/colors';
 
 export default {
   content: ['./src/**/*.{html,ts}'],
@@ -8,9 +7,6 @@ export default {
     extend: {
       fontFamily: {
         sans: ['objektiv-mk1', 'sans-serif'],
-      },
-      colors: {
-        'error-red': red['700'],
       },
     },
   },


### PR DESCRIPTION
[SFD-143 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-143)

Changes the the error messages in dark mode to white text on a red background so they are easier to read.

![dark-mode-error-message](https://github.com/user-attachments/assets/27b2f7a0-2a36-45b6-915e-9136ed2d4582)
