### PR TITLE
SFD-167: Expansion panel button bugfix

### DIFF
--- a/src/app/expansion-panel/expansion-panel.component.html
+++ b/src/app/expansion-panel/expansion-panel.component.html
@@ -3,7 +3,6 @@
   <button
     type="button"
     (click)="toggle()"
-    (keydown.enter)="toggle()"
     [class]="config.buttonStyles"
     [attr.aria-label]="expanded ? 'Hide details' : 'Show details'">
     {{ expanded ? 'expand_less' : 'expand_more' }}


### PR DESCRIPTION
[SFD-167 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-167)

Fixes an issue where the buttons that expand and collapse the expansion panels don't work with the `enter` key.

Notes:
- This was caused by having both a `(click)` and a `(keydown.enter)` handler on the [button](https://github.com/ScottLogic/sl-tech-carbon-estimator/blob/main/src/app/expansion-panel/expansion-panel.component.html#L5-L6). (Previously this wasn’t a button HTML element and so both were required but now it’s a button element pressing enter fires the `(click)` event and the `(keydown.enter)` event is no longer needed.)