### PR TITLE
SFD-128: Add error summary for validation errors

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -1,7 +1,7 @@
 <form (ngSubmit)="handleSubmit()" [formGroup]="estimatorForm" class="tce-w-full tce-flex tce-flex-col tce-gap-6">
   <div formGroupName="upstream">
     @if (showErrorSummary) {
-      <error-summary [validationErrors]="getValidationErrors()"></error-summary>
+      <error-summary [validationErrors]="validationErrors"></error-summary>
     }
 
     <ng-container *ngTemplateOutlet="sectionHeader; context: formContext.upstream"></ng-container>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -85,7 +85,7 @@
           required
           [attr.aria-describedby]="(numberOfServers | invalidated) ? 'numberOfServersError' : null" />
         @if (numberOfServers | invalidated) {
-          <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
+          <div class="tce-error-box tce-flex tce-items-center tce-gap-1" aria-live="polite" id="numberOfServersError">
             <span class="material-icons-outlined">error</span>
             <p>{{ errorConfig.numberOfServers.errorMessage }}</p>
           </div>
@@ -214,7 +214,10 @@
             required
             [attr.aria-describedby]="(monthlyActiveUsers | invalidated) ? 'monthlyActiveUsersError' : null" />
           @if (monthlyActiveUsers | invalidated) {
-            <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
+            <div
+              class="tce-error-box tce-flex tce-items-center tce-gap-1"
+              aria-live="polite"
+              id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>{{ errorConfig.monthlyActiveUsers.errorMessage }}</p>
             </div>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -20,7 +20,7 @@
         @if (headCount | invalidated) {
           <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="headCountError">
             <span class="material-icons-outlined">error</span>
-            <p>{{ errorMessages.headCount }}</p>
+            <p>{{ errorConfig.headCount.errorMessage }}</p>
           </div>
         }
       </div>
@@ -87,7 +87,7 @@
         @if (numberOfServers | invalidated) {
           <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
             <span class="material-icons-outlined">error</span>
-            <p>{{ errorMessages.numberOfServers }}</p>
+            <p>{{ errorConfig.numberOfServers.errorMessage }}</p>
           </div>
         }
       </div>
@@ -217,7 +217,7 @@
             <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>
-                {{ errorMessages.monthlyActiveUsers }}. To specify no external users, use the
+                {{ errorConfig.monthlyActiveUsers.errorMessage }}. To specify no external users, use the
                 <a class="tce-underline" href="#noDownstream">checkbox</a> above.
               </p>
             </div>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -16,7 +16,7 @@
         @if (headCount | invalidated) {
           <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="headCountError">
             <span class="material-icons-outlined">error</span>
-            <p>The number of employees must be greater than 0.</p>
+            <p>{{ errorMessages.headCount }}</p>
           </div>
         }
       </div>
@@ -83,7 +83,7 @@
         @if (numberOfServers | invalidated) {
           <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="numberOfServersError">
             <span class="material-icons-outlined">error</span>
-            <p>The number of servers must be greater than or equal to 0.</p>
+            <p>{{ errorMessages.numberOfServers }}</p>
           </div>
         }
       </div>
@@ -213,7 +213,7 @@
             <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>
-                Monthly active users must be greater than 0. To specify no external users, use the
+                {{ errorMessages.monthlyActiveUsers }} To specify no external users, use the
                 <a class="tce-underline" href="#noDownstream">checkbox</a> above.
               </p>
             </div>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -217,7 +217,7 @@
             <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
               <p>
-                {{ errorMessages.monthlyActiveUsers }} To specify no external users, use the
+                {{ errorMessages.monthlyActiveUsers }}. To specify no external users, use the
                 <a class="tce-underline" href="#noDownstream">checkbox</a> above.
               </p>
             </div>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -262,35 +262,8 @@
   <div>
     <div class="tce-flex tce-gap-4 tce-justify-end">
       <button class="tce-button-reset tce-px-3 tce-py-2" type="button" (click)="resetForm()">Reset</button>
-      <button
-        class="tce-button-calculate tce-px-3 tce-py-2"
-        [ngClass]="{ 'tce-opacity-50 tce-cursor-not-allowed': estimatorForm.invalid }"
-        type="submit"
-        [attr.aria-disabled]="estimatorForm.invalid"
-        [attr.aria-describedby]="(estimatorForm | invalidated) ? 'calculateDisabledMessage' : null">
-        Calculate
-      </button>
+      <button class="tce-button-calculate tce-px-3 tce-py-2" type="submit">Calculate</button>
     </div>
-    @if (estimatorForm | invalidated) {
-      <div
-        class="tce-error-box tce-flex tce-gap-1 tce-justify-end tce-mt-2"
-        aria-live="polite"
-        id="calculateDisabledMessage">
-        <span class="material-icons-outlined">error</span>
-        <p>
-          Unable to calculate emissions because the following fields are invalid:
-          @if (headCount?.invalid) {
-            <a class="tce-underline" href="#headCount">number of employees</a>&nbsp;
-          }
-          @if (numberOfServers?.invalid) {
-            <a class="tce-underline" href="#numberOfServers">number of servers</a>&nbsp;
-          }
-          @if (monthlyActiveUsers?.invalid) {
-            <a class="tce-underline" href="#monthlyActiveUsers">monthly active users</a>
-          }
-        </p>
-      </div>
-    }
   </div>
 
   <ng-template

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -1,5 +1,9 @@
 <form (ngSubmit)="handleSubmit()" [formGroup]="estimatorForm" class="tce-w-full tce-flex tce-flex-col tce-gap-6">
   <div formGroupName="upstream">
+    @if (showErrorSummary) {
+      <error-summary [validationErrors]="getValidationErrors()"></error-summary>
+    }
+
     <ng-container *ngTemplateOutlet="sectionHeader; context: formContext.upstream"></ng-container>
 
     <div class="tce-flex tce-flex-col tce-gap-4">

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -18,7 +18,7 @@
           required
           [attr.aria-describedby]="(headCount | invalidated) ? 'headCountError' : null" />
         @if (headCount | invalidated) {
-          <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="headCountError">
+          <div class="tce-error-box tce-flex tce-items-center tce-gap-1" aria-live="polite" id="headCountError">
             <span class="material-icons-outlined">error</span>
             <p>{{ errorConfig.headCount.errorMessage }}</p>
           </div>
@@ -216,10 +216,7 @@
           @if (monthlyActiveUsers | invalidated) {
             <div class="tce-error-box tce-flex tce-gap-1" aria-live="polite" id="monthlyActiveUsersError">
               <span class="material-icons-outlined">error</span>
-              <p>
-                {{ errorConfig.monthlyActiveUsers.errorMessage }}. To specify no external users, use the
-                <a class="tce-underline" href="#noDownstream">checkbox</a> above.
-              </p>
+              <p>{{ errorConfig.monthlyActiveUsers.errorMessage }}</p>
             </div>
           }
         </div>

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -26,11 +26,7 @@ export type ValidationError = {
   errorMessage: string;
 };
 
-const errorConfig: {
-  headCount: ValidationError;
-  numberOfServers: ValidationError;
-  monthlyActiveUsers: ValidationError;
-} = {
+const errorConfig = {
   headCount: {
     inputId: 'headCount',
     errorMessage: 'The number of employees must be greater than 0',

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -86,8 +86,8 @@ export class CarbonEstimatorFormComponent implements OnInit {
   public questionPanelConfig = questionPanelConfig;
 
   public errorMessages = errorMessages;
-
   public showErrorSummary = false;
+  public validationErrors: ValidationError[] = [];
 
   constructor(
     private formBuilder: FormBuilder,
@@ -179,6 +179,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
   public handleSubmit() {
     if (!this.estimatorForm.valid) {
       this.showErrorSummary = true;
+      this.validationErrors = this.getValidationErrors();
       this.changeDetector.detectChanges();
       this.errorSummary?.summary.nativeElement.focus();
       return;
@@ -222,7 +223,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
     }
   }
 
-  public getValidationErrors() {
+  private getValidationErrors() {
     const validationErrors: ValidationError[] = [];
     if (this.headCount?.invalid) {
       validationErrors.push({

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -2,13 +2,7 @@ import { CommonModule, JsonPipe } from '@angular/common';
 import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output, ViewChild, input } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { EstimatorFormValues, EstimatorValues, WorldLocation, locationArray } from '../types/carbon-estimator';
-import {
-  costRanges,
-  defaultValues,
-  formContext,
-  questionPanelConfig,
-  ValidationError,
-} from './carbon-estimator-form.constants';
+import { costRanges, defaultValues, formContext, questionPanelConfig } from './carbon-estimator-form.constants';
 import { NoteComponent } from '../note/note.component';
 import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.component';
@@ -27,10 +21,28 @@ const locationDescriptions: Record<WorldLocation, string> = {
   'LATIN AMERICA AND CARIBBEAN': 'in Latin America or the Caribbean',
 };
 
-const errorMessages = {
-  headCount: 'The number of employees must be greater than 0',
-  numberOfServers: 'The number of servers must be greater than or equal to 0',
-  monthlyActiveUsers: 'The number of monthly active users must be greater than 0',
+export type ValidationError = {
+  inputId: string;
+  errorMessage: string;
+};
+
+const errorConfig: {
+  headCount: ValidationError;
+  numberOfServers: ValidationError;
+  monthlyActiveUsers: ValidationError;
+} = {
+  headCount: {
+    inputId: 'headCount',
+    errorMessage: 'The number of employees must be greater than 0',
+  },
+  numberOfServers: {
+    inputId: 'numberOfServers',
+    errorMessage: 'The number of servers must be greater than or equal to 0',
+  },
+  monthlyActiveUsers: {
+    inputId: 'monthlyActiveUsers',
+    errorMessage: 'The number of monthly active users must be greater than 0',
+  },
 };
 
 @Component({
@@ -85,7 +97,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
 
   public questionPanelConfig = questionPanelConfig;
 
-  public errorMessages = errorMessages;
+  public errorConfig = errorConfig;
   public showErrorSummary = false;
   public validationErrors: ValidationError[] = [];
 
@@ -226,22 +238,13 @@ export class CarbonEstimatorFormComponent implements OnInit {
   private getValidationErrors() {
     const validationErrors: ValidationError[] = [];
     if (this.headCount?.invalid) {
-      validationErrors.push({
-        inputId: 'headCount',
-        errorMessage: this.errorMessages.headCount,
-      });
+      validationErrors.push(this.errorConfig.headCount);
     }
     if (this.numberOfServers?.invalid) {
-      validationErrors.push({
-        inputId: 'numberOfServers',
-        errorMessage: this.errorMessages.numberOfServers,
-      });
+      validationErrors.push(this.errorConfig.numberOfServers);
     }
     if (this.monthlyActiveUsers?.invalid) {
-      validationErrors.push({
-        inputId: 'monthlyActiveUsers',
-        errorMessage: this.errorMessages.monthlyActiveUsers,
-      });
+      validationErrors.push(this.errorConfig.monthlyActiveUsers);
     }
 
     return validationErrors;

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -14,6 +14,7 @@ import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.component';
 import { FormatCostRangePipe } from '../pipes/format-cost-range.pipe';
 import { InvalidatedPipe } from '../pipes/invalidated.pipe';
+import { ErrorSummaryComponent } from '../error-summary/error-summary.component';
 
 const locationDescriptions: Record<WorldLocation, string> = {
   WORLD: 'Globally',
@@ -46,6 +47,7 @@ const errorMessages = {
     ExpansionPanelComponent,
     FormatCostRangePipe,
     InvalidatedPipe,
+    ErrorSummaryComponent,
   ],
 })
 export class CarbonEstimatorFormComponent implements OnInit {
@@ -82,6 +84,8 @@ export class CarbonEstimatorFormComponent implements OnInit {
   public questionPanelConfig = questionPanelConfig;
 
   public errorMessages = errorMessages;
+
+  public showErrorSummary = false;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -172,8 +176,10 @@ export class CarbonEstimatorFormComponent implements OnInit {
 
   public handleSubmit() {
     if (!this.estimatorForm.valid) {
+      this.showErrorSummary = true;
       return;
     }
+    this.showErrorSummary = false;
     const formValue = this.estimatorForm.getRawValue();
     if (formValue.onPremise.serverLocation === 'unknown') {
       formValue.onPremise.serverLocation = 'WORLD';
@@ -212,7 +218,7 @@ export class CarbonEstimatorFormComponent implements OnInit {
     }
   }
 
-  private getValidationErrors() {
+  public getValidationErrors() {
     const validationErrors: ValidationError[] = [];
     if (this.headCount?.invalid) {
       validationErrors.push({

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -2,44 +2,21 @@ import { CommonModule, JsonPipe } from '@angular/common';
 import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output, ViewChild, input } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { EstimatorFormValues, EstimatorValues, WorldLocation, locationArray } from '../types/carbon-estimator';
-import { costRanges, defaultValues, formContext, questionPanelConfig } from './carbon-estimator-form.constants';
+import {
+  costRanges,
+  defaultValues,
+  formContext,
+  questionPanelConfig,
+  locationDescriptions,
+  ValidationError,
+  errorConfig,
+} from './carbon-estimator-form.constants';
 import { NoteComponent } from '../note/note.component';
 import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.component';
 import { FormatCostRangePipe } from '../pipes/format-cost-range.pipe';
 import { InvalidatedPipe } from '../pipes/invalidated.pipe';
 import { ErrorSummaryComponent } from '../error-summary/error-summary.component';
-
-const locationDescriptions: Record<WorldLocation, string> = {
-  WORLD: 'Globally',
-  'NORTH AMERICA': 'in North America',
-  EUROPE: 'in Europe',
-  GBR: 'in the UK',
-  ASIA: 'in Asia',
-  AFRICA: 'in Africa',
-  OCEANIA: 'in Oceania',
-  'LATIN AMERICA AND CARIBBEAN': 'in Latin America or the Caribbean',
-};
-
-export type ValidationError = {
-  inputId: string;
-  errorMessage: string;
-};
-
-const errorConfig = {
-  headCount: {
-    inputId: 'headCount',
-    errorMessage: 'The number of employees must be greater than 0',
-  },
-  numberOfServers: {
-    inputId: 'numberOfServers',
-    errorMessage: 'The number of servers must be greater than or equal to 0',
-  },
-  monthlyActiveUsers: {
-    inputId: 'monthlyActiveUsers',
-    errorMessage: 'The number of monthly active users must be greater than 0',
-  },
-};
 
 @Component({
   selector: 'carbon-estimator-form',

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, JsonPipe } from '@angular/common';
-import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output, input } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output, ViewChild, input } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { EstimatorFormValues, EstimatorValues, WorldLocation, locationArray } from '../types/carbon-estimator';
 import {
@@ -55,6 +55,8 @@ export class CarbonEstimatorFormComponent implements OnInit {
 
   @Output() public formSubmit: EventEmitter<EstimatorValues> = new EventEmitter<EstimatorValues>();
   @Output() public formReset: EventEmitter<void> = new EventEmitter();
+
+  @ViewChild(ErrorSummaryComponent) errorSummary?: ErrorSummaryComponent;
 
   public estimatorForm!: FormGroup<EstimatorFormValues>;
 
@@ -177,6 +179,8 @@ export class CarbonEstimatorFormComponent implements OnInit {
   public handleSubmit() {
     if (!this.estimatorForm.valid) {
       this.showErrorSummary = true;
+      this.changeDetector.detectChanges();
+      this.errorSummary?.summary.nativeElement.focus();
       return;
     }
     this.showErrorSummary = false;

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -28,9 +28,9 @@ const locationDescriptions: Record<WorldLocation, string> = {
 };
 
 const errorMessages = {
-  headCount: 'The number of employees must be greater than 0.',
-  numberOfServers: 'The number of servers must be greater than or equal to 0.',
-  monthlyActiveUsers: 'The number of monthly active users must be greater than 0.',
+  headCount: 'The number of employees must be greater than 0',
+  numberOfServers: 'The number of servers must be greater than or equal to 0',
+  monthlyActiveUsers: 'The number of monthly active users must be greater than 0',
 };
 
 @Component({

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -185,9 +185,9 @@ export class CarbonEstimatorFormComponent implements OnInit {
   }
 
   public handleSubmit() {
-    if (!this.estimatorForm.valid) {
-      this.showErrorSummary = true;
+    if (this.estimatorForm.invalid) {
       this.validationErrors = this.getValidationErrors();
+      this.showErrorSummary = true;
       this.changeDetector.detectChanges();
       this.errorSummary?.summary.nativeElement.focus();
       return;

--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -2,7 +2,13 @@ import { CommonModule, JsonPipe } from '@angular/common';
 import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output, input } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { EstimatorFormValues, EstimatorValues, WorldLocation, locationArray } from '../types/carbon-estimator';
-import { costRanges, defaultValues, formContext, questionPanelConfig } from './carbon-estimator-form.constants';
+import {
+  costRanges,
+  defaultValues,
+  formContext,
+  questionPanelConfig,
+  ValidationError,
+} from './carbon-estimator-form.constants';
 import { NoteComponent } from '../note/note.component';
 import { CarbonEstimationService } from '../services/carbon-estimation.service';
 import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.component';
@@ -18,6 +24,12 @@ const locationDescriptions: Record<WorldLocation, string> = {
   AFRICA: 'in Africa',
   OCEANIA: 'in Oceania',
   'LATIN AMERICA AND CARIBBEAN': 'in Latin America or the Caribbean',
+};
+
+const errorMessages = {
+  headCount: 'The number of employees must be greater than 0.',
+  numberOfServers: 'The number of servers must be greater than or equal to 0.',
+  monthlyActiveUsers: 'The number of monthly active users must be greater than 0.',
 };
 
 @Component({
@@ -68,6 +80,8 @@ export class CarbonEstimatorFormComponent implements OnInit {
   }));
 
   public questionPanelConfig = questionPanelConfig;
+
+  public errorMessages = errorMessages;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -196,5 +210,29 @@ export class CarbonEstimatorFormComponent implements OnInit {
         this.estimatorForm.getRawValue() as EstimatorValues
       );
     }
+  }
+
+  private getValidationErrors() {
+    const validationErrors: ValidationError[] = [];
+    if (this.headCount?.invalid) {
+      validationErrors.push({
+        inputId: 'headCount',
+        errorMessage: this.errorMessages.headCount,
+      });
+    }
+    if (this.numberOfServers?.invalid) {
+      validationErrors.push({
+        inputId: 'numberOfServers',
+        errorMessage: this.errorMessages.numberOfServers,
+      });
+    }
+    if (this.monthlyActiveUsers?.invalid) {
+      validationErrors.push({
+        inputId: 'monthlyActiveUsers',
+        errorMessage: this.errorMessages.monthlyActiveUsers,
+      });
+    }
+
+    return validationErrors;
   }
 }

--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -97,8 +97,3 @@ export const questionPanelConfig: ExpansionPanelConfig = {
   buttonStyles: 'material-icons-outlined tce-text-base hover:tce-bg-slate-200 hover:tce-rounded',
   contentContainerStyles: 'tce-px-3 tce-py-2 tce-bg-slate-100 tce-border tce-border-slate-400 tce-rounded tce-text-sm',
 };
-
-export type ValidationError = {
-  inputId: string;
-  errorMessage: string;
-};

--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -97,3 +97,8 @@ export const questionPanelConfig: ExpansionPanelConfig = {
   buttonStyles: 'material-icons-outlined tce-text-base hover:tce-bg-slate-200 hover:tce-rounded',
   contentContainerStyles: 'tce-px-3 tce-py-2 tce-bg-slate-100 tce-border tce-border-slate-400 tce-rounded tce-text-sm',
 };
+
+export type ValidationError = {
+  inputId: string;
+  errorMessage: string;
+};

--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -1,5 +1,6 @@
 import { ExpansionPanelConfig } from '../expansion-panel/expansion-panel.constants';
 import { CostRange, EstimatorValues } from '../types/carbon-estimator';
+import { WorldLocation } from '../types/carbon-estimator';
 
 export const costRanges: CostRange[] = [
   { min: 0, max: 1000 },
@@ -96,4 +97,35 @@ export const questionPanelConfig: ExpansionPanelConfig = {
   startsExpanded: false,
   buttonStyles: 'material-icons-outlined tce-text-base hover:tce-bg-slate-200 hover:tce-rounded',
   contentContainerStyles: 'tce-px-3 tce-py-2 tce-bg-slate-100 tce-border tce-border-slate-400 tce-rounded tce-text-sm',
+};
+
+export const locationDescriptions: Record<WorldLocation, string> = {
+  WORLD: 'Globally',
+  'NORTH AMERICA': 'in North America',
+  EUROPE: 'in Europe',
+  GBR: 'in the UK',
+  ASIA: 'in Asia',
+  AFRICA: 'in Africa',
+  OCEANIA: 'in Oceania',
+  'LATIN AMERICA AND CARIBBEAN': 'in Latin America or the Caribbean',
+};
+
+export type ValidationError = {
+  inputId: string;
+  errorMessage: string;
+};
+
+export const errorConfig = {
+  headCount: {
+    inputId: 'headCount',
+    errorMessage: 'The number of employees must be greater than 0',
+  },
+  numberOfServers: {
+    inputId: 'numberOfServers',
+    errorMessage: 'The number of servers must be greater than or equal to 0',
+  },
+  monthlyActiveUsers: {
+    inputId: 'monthlyActiveUsers',
+    errorMessage: 'The number of monthly active users must be greater than 0',
+  },
 };

--- a/src/app/error-summary/error-summary.component.html
+++ b/src/app/error-summary/error-summary.component.html
@@ -1,0 +1,10 @@
+<div class="tce-border-4 tce-rounded tce-border-red-600 tce-p-2">
+  <h2 class="tce-text-2xl"><strong>There is a problem</strong></h2>
+  <ul class="tce-text-red-600">
+    @for (error of validationErrors(); track $index) {
+      <li>
+        <a class="tce-underline" href="#{{ error.inputId }}">{{ error.errorMessage }}</a>
+      </li>
+    }
+  </ul>
+</div>

--- a/src/app/error-summary/error-summary.component.html
+++ b/src/app/error-summary/error-summary.component.html
@@ -1,8 +1,8 @@
-<div #errorSummary tabindex="-1" class="tce-border-4 tce-rounded tce-border-red-600 tce-p-3 tce-mt-2 tce-mb-5">
+<div #errorSummary tabindex="-1" class="tce-error-summary tce-border-4 tce-rounded tce-p-3 tce-mt-2 tce-mb-5">
   <h2 class="tce-text-2xl"><strong>There is a problem</strong></h2>
-  <div class="tce-flex tce-flex-col tce-gap-1 tce-mt-1 tce-text-red-600">
+  <div class="tce-flex tce-flex-col tce-gap-1 tce-mt-1">
     @for (error of validationErrors(); track $index) {
-      <a class="tce-underline" href="#{{ error.inputId }}"
+      <a class="tce-error-summary-link tce-underline" href="#{{ error.inputId }}"
         ><strong>{{ error.errorMessage }}</strong></a
       >
     }

--- a/src/app/error-summary/error-summary.component.html
+++ b/src/app/error-summary/error-summary.component.html
@@ -1,10 +1,10 @@
-<div #errorSummary tabindex="-1" class="tce-border-4 tce-rounded tce-border-red-600 tce-p-2">
+<div #errorSummary tabindex="-1" class="tce-border-4 tce-rounded tce-border-red-600 tce-p-3 tce-mt-2 tce-mb-5">
   <h2 class="tce-text-2xl"><strong>There is a problem</strong></h2>
-  <ul class="tce-text-red-600">
+  <div class="tce-flex tce-flex-col tce-gap-1 tce-mt-1 tce-text-red-600">
     @for (error of validationErrors(); track $index) {
-      <li>
-        <a class="tce-underline" href="#{{ error.inputId }}">{{ error.errorMessage }}</a>
-      </li>
+      <a class="tce-underline" href="#{{ error.inputId }}"
+        ><strong>{{ error.errorMessage }}</strong></a
+      >
     }
-  </ul>
+  </div>
 </div>

--- a/src/app/error-summary/error-summary.component.html
+++ b/src/app/error-summary/error-summary.component.html
@@ -1,4 +1,4 @@
-<div class="tce-border-4 tce-rounded tce-border-red-600 tce-p-2">
+<div #errorSummary tabindex="-1" class="tce-border-4 tce-rounded tce-border-red-600 tce-p-2">
   <h2 class="tce-text-2xl"><strong>There is a problem</strong></h2>
   <ul class="tce-text-red-600">
     @for (error of validationErrors(); track $index) {

--- a/src/app/error-summary/error-summary.component.spec.ts
+++ b/src/app/error-summary/error-summary.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ErrorSummaryComponent } from './error-summary.component';
-import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.component';
+import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.constants';
 
 describe('ErrorSummaryComponent', () => {
   let component: ErrorSummaryComponent;

--- a/src/app/error-summary/error-summary.component.spec.ts
+++ b/src/app/error-summary/error-summary.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorSummaryComponent } from './error-summary.component';
+
+describe('ErrorSummaryComponent', () => {
+  let component: ErrorSummaryComponent;
+  let fixture: ComponentFixture<ErrorSummaryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ErrorSummaryComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ErrorSummaryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/error-summary/error-summary.component.spec.ts
+++ b/src/app/error-summary/error-summary.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ErrorSummaryComponent } from './error-summary.component';
+import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.component';
 
 describe('ErrorSummaryComponent', () => {
   let component: ErrorSummaryComponent;
@@ -13,10 +14,29 @@ describe('ErrorSummaryComponent', () => {
 
     fixture = TestBed.createComponent(ErrorSummaryComponent);
     component = fixture.componentInstance;
+
+    const validationErrors: ValidationError[] = [
+      {
+        inputId: 'input1',
+        errorMessage: 'Input 1 must be greater than 0',
+      },
+      {
+        inputId: 'input2',
+        errorMessage: 'Input 2 must be greater than 0',
+      },
+    ];
+
+    fixture.componentRef.setInput('validationErrors', validationErrors);
+
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display validation error messages', () => {
+    expect(fixture.nativeElement.textContent).toContain('Input 1 must be greater than 0');
+    expect(fixture.nativeElement.textContent).toContain('Input 2 must be greater than 0');
   });
 });

--- a/src/app/error-summary/error-summary.component.ts
+++ b/src/app/error-summary/error-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, ElementRef, input, ViewChild } from '@angular/core';
 import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.constants';
 
 @Component({
@@ -10,4 +10,5 @@ import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.
 })
 export class ErrorSummaryComponent {
   validationErrors = input.required<ValidationError[]>();
+  @ViewChild('errorSummary') summary!: ElementRef<HTMLDivElement>;
 }

--- a/src/app/error-summary/error-summary.component.ts
+++ b/src/app/error-summary/error-summary.component.ts
@@ -1,0 +1,13 @@
+import { Component, input } from '@angular/core';
+import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.constants';
+
+@Component({
+  selector: 'error-summary',
+  standalone: true,
+  imports: [],
+  templateUrl: './error-summary.component.html',
+  styleUrl: './error-summary.component.css',
+})
+export class ErrorSummaryComponent {
+  validationErrors = input.required<ValidationError[]>();
+}

--- a/src/app/error-summary/error-summary.component.ts
+++ b/src/app/error-summary/error-summary.component.ts
@@ -6,7 +6,6 @@ import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.
   standalone: true,
   imports: [],
   templateUrl: './error-summary.component.html',
-  styleUrl: './error-summary.component.css',
 })
 export class ErrorSummaryComponent {
   validationErrors = input.required<ValidationError[]>();

--- a/src/app/error-summary/error-summary.component.ts
+++ b/src/app/error-summary/error-summary.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, input, ViewChild } from '@angular/core';
-import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.constants';
+import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.component';
 
 @Component({
   selector: 'error-summary',

--- a/src/app/error-summary/error-summary.component.ts
+++ b/src/app/error-summary/error-summary.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, input, ViewChild } from '@angular/core';
-import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.component';
+import { ValidationError } from '../carbon-estimator-form/carbon-estimator-form.constants';
 
 @Component({
   selector: 'error-summary',

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -9,7 +9,7 @@
           aria-live="polite"
           (closeEvent)="closeAssumptionsAndLimitation($event)"></assumptions-and-limitation>
       } @else {
-        <div class="tce-flex tce-justify-end tce-pb-4 -tce-mt-2">
+        <div class="tce-flex tce-justify-end tce-mb-4 -tce-mt-2">
           <button
             #showAssumptionsLimitationButton
             class="tce-button-assumptions tce-px-3 tce-py-2 tce-w-fit tce-self-end"

--- a/src/package-styles.css
+++ b/src/package-styles.css
@@ -1,17 +1,26 @@
 @media (prefers-color-scheme: dark) {
   .apexcharts-legend-text {
-    @apply !tce-text-slate-50
+    @apply !tce-text-slate-50;
   }
 
-  input, select {
-    @apply tce-text-slate-600
+  input,
+  select {
+    @apply tce-text-slate-600;
   }
 
   input.ng-invalid.ng-touched {
-    @apply tce-border-red-700
+    @apply tce-border-red-700;
   }
 
   .tce-error-box {
-    @apply tce-text-white tce-bg-red-700 tce-p-1 tce-rounded tce-border tce-border-white
+    @apply tce-text-white tce-bg-red-700 tce-p-1 tce-rounded tce-border tce-border-white;
+  }
+
+  .tce-error-summary {
+    @apply tce-text-white tce-bg-red-700 tce-border-white;
+  }
+
+  .tce-error-summary-link {
+    @apply tce-text-white;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,21 +3,31 @@
 @tailwind utilities;
 
 input.ng-invalid.ng-touched {
-  @apply tce-border-red-600 tce-border-2 tce-m-[-1px]
+  @apply tce-border-red-600 tce-border-2 tce-m-[-1px];
 }
 
 .tce-error-box {
-  @apply tce-text-red-600
+  @apply tce-text-red-600;
+}
+
+.tce-error-summary {
+  @apply tce-border-red-600;
+}
+
+.tce-error-summary-link {
+  @apply tce-text-red-600;
 }
 
 .tce-note {
-  @apply tce-bg-sky-200 tce-border-sky-400 tce-text-slate-800
+  @apply tce-bg-sky-200 tce-border-sky-400 tce-text-slate-800;
 }
 
-.tce-button-calculate, .tce-button-close {
-  @apply tce-bg-sky-800 tce-text-white hover:tce-bg-sky-900 tce-rounded
+.tce-button-calculate,
+.tce-button-close {
+  @apply tce-bg-sky-800 tce-text-white hover:tce-bg-sky-900 tce-rounded;
 }
 
-.tce-button-reset, .tce-button-assumptions {
-  @apply tce-bg-slate-200 tce-text-slate-800 hover:tce-bg-slate-300 tce-rounded
+.tce-button-reset,
+.tce-button-assumptions {
+  @apply tce-bg-slate-200 tce-text-slate-800 hover:tce-bg-slate-300 tce-rounded;
 }


### PR DESCRIPTION
[SFD-128 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-128)

Adds an error summary to display form validation errors. Includes links to the invalid input fields.

Notes:
-   The 'calculate' button was previously disabled when there were validation errors. It has been enabled at all times but the error summary will be shown if there are validation errors. This is so that the error feedback is the same whether the form is submitted using the 'enter' key or the 'calculate' button. 


Error summary:
![error-summary](https://github.com/user-attachments/assets/58d508bd-277f-4182-a451-508fd9e53247)


Error summary dark mode:
![error-summary-dark-mode](https://github.com/user-attachments/assets/7a211004-b28b-4709-a900-197148f00f31)
