### PR TITLE
SFD-200: Persist diagram display

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.ts
@@ -98,6 +98,7 @@ export class CarbonEstimatorFormComponent implements OnInit, OnDestroy {
     showErrorSummary: false,
     validationErrors: [],
   };
+  public submitted = false;
 
   public compareCostRanges = compareCostRanges;
 
@@ -193,7 +194,9 @@ export class CarbonEstimatorFormComponent implements OnInit, OnDestroy {
     if (storedFormState) {
       this.estimatorForm.setValue(storedFormState.formValue);
       this.setControlStates(storedFormState.controlStates);
-      this.errorSummaryState = storedFormState.errorSummaryState;
+      if (storedFormState.submitted) {
+        this.handleSubmit();
+      }
     }
   }
 
@@ -202,6 +205,7 @@ export class CarbonEstimatorFormComponent implements OnInit, OnDestroy {
   }
 
   public handleSubmit() {
+    this.submitted = true;
     if (this.estimatorForm.invalid) {
       this.errorSummaryState = {
         showErrorSummary: true,
@@ -227,6 +231,7 @@ export class CarbonEstimatorFormComponent implements OnInit, OnDestroy {
 
   public resetForm() {
     this.estimatorForm.reset();
+    this.submitted = false;
     this.resetValidationErrors();
     this.clearStoredFormState();
     this.formReset.emit();
@@ -279,7 +284,7 @@ export class CarbonEstimatorFormComponent implements OnInit, OnDestroy {
   }
 
   private storeFormState() {
-    this.formStateService.storeFormState(this.estimatorForm, this.errorSummaryState);
+    this.formStateService.storeFormState(this.estimatorForm, this.submitted);
   }
 
   private getStoredFormState() {

--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -145,5 +145,5 @@ export type ErrorSummaryState = {
 export type FormState = {
   formValue: EstimatorFormRawValue;
   controlStates: Record<string, ControlState>;
-  errorSummaryState: ErrorSummaryState;
+  submitted: boolean;
 };

--- a/src/app/services/form-state.service.ts
+++ b/src/app/services/form-state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { StorageService } from './storage.service';
 import { FormGroup } from '@angular/forms';
-import { ControlState, ErrorSummaryState, FormState } from '../carbon-estimator-form/carbon-estimator-form.constants';
+import { ControlState, FormState } from '../carbon-estimator-form/carbon-estimator-form.constants';
 import { EstimatorFormValues } from '../types/carbon-estimator';
 
 @Injectable({
@@ -39,11 +39,11 @@ export class FormStateService {
     }
   }
 
-  storeFormState(estimatorForm: FormGroup<EstimatorFormValues>, errorSummaryState: ErrorSummaryState) {
+  storeFormState(estimatorForm: FormGroup<EstimatorFormValues>, submitted: boolean) {
     const formState: FormState = {
       formValue: estimatorForm.getRawValue(),
       controlStates: this.getControlStates(estimatorForm),
-      errorSummaryState,
+      submitted,
     };
     this.storageService.set('formState', JSON.stringify(formState));
   }


### PR DESCRIPTION
[SFD-200 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-200)

## Description of Change

Restore the diagram state when navigating away from the site and returning.

Possibly one for @jantoun-scottlogic to review the approach, as it seemed simplest to just call `handleSubmit()` if it was done previously, instead of having the diagram store state as well. There are some edge cases, where the form has been changed but not resubmitted before navigating away and it also does not restore which display tab was active when looking at the table.

I also didn't need to update any tests to make this change but I wasn't sure whether to get into checking what the form storage service was called with and how the init process changes when existing state is found.

## Checklist

- [ ] tests are updated or added
