### PR TITLE
SFD-193: Avoid duplication of build and test steps in publish pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,47 +3,16 @@ name: Deploy estimator Pages
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  workflow_call:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
 
 jobs:
-  # Build job
-  build_page:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up environment
-        uses: ./.github/actions/set-up-environment
-      - name: Build app
-        run: npm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist/tech-carbon-estimator
-
   build_and_test:
     uses: ./.github/workflows/buildAndTest.yml
-    needs: build_page
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+  publish_pages:
     needs: build_and_test
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/shared-pages.yml

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -121,4 +121,4 @@ jobs:
       pages: write
       id-token: write
       contents: read
-    uses: ./.github/workflows/pages.yml
+    uses: ./.github/workflows/shared-pages.yml

--- a/.github/workflows/shared-pages.yml
+++ b/.github/workflows/shared-pages.yml
@@ -1,0 +1,44 @@
+name: Shared Pages publish workflow
+
+on:
+  # Only intended to be called from other workflows
+  workflow_call:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build_page:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/actions/set-up-environment
+      - name: Build app
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist/tech-carbon-estimator
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build_page
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!-- Remove if issue not tracked via Jira -->
[SFD-193 Jira ticket](https://scottlogic.atlassian.net/browse/SFD-193)

## Description of Change

Add a shared workflow to publish pages, which can only be called from other workflows. There are now 3 workflows that can be triggered manually:

- **Build and Test** (`buildAndTest.yml`)
- **Deploy estimator pages** (`pages.yml`)
- **Publish new package** (`publish-package.yml`)

And one that can only be called from others:

- **Shared Pages publish workflow** (`shared-pages.yml`)

**Deploy estimator pages** is now a simple workflow that only calls other workflows, `buildAndTest` followed by `shared-pages`.  In theory we should not need to use this in future but we will keep it for now. **Publish new package** has only changed to call `shared-pages`.
