### PR TITLE
fix: Colour contrast for expansion panels is not suitable ratio in darkmode

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.constants.ts
@@ -96,7 +96,7 @@ export const formContext = {
 export const questionPanelConfig: ExpansionPanelConfig = {
   startsExpanded: false,
   buttonStyles: 'material-icons-outlined tce-text-base hover:tce-bg-slate-200 hover:tce-rounded',
-  contentContainerStyles: 'tce-px-3 tce-py-2 tce-bg-slate-100 tce-border tce-border-slate-400 tce-rounded tce-text-sm',
+  contentContainerStyles: 'tce-px-3 tce-py-2 tce-bg-slate-100 tce-border tce-border-slate-400 tce-rounded tce-text-sm dark:tce-text-slate-800',
 };
 
 export const locationDescriptions: Record<WorldLocation, string> = {


### PR DESCRIPTION
Issue #180

## Description of Change

- Specified text colour for question expansion panels when in dark mode

## Screenshot

<img width="934" height="571" alt="image" src="https://github.com/user-attachments/assets/14d8c01f-7b49-47e4-8774-8d5dde2c970f" />

(Page looks different due to tailwind issues that need to be resolved. Have confirmed that without this change, the text is still shown as white in latest develop)