### PR TITLE
#145 Create Downstream Infrastructure emissions type for schema v0.0.2

### DIFF
--- a/src/app/carbon-estimation-table/carbon-estimation-table.component.spec.ts
+++ b/src/app/carbon-estimation-table/carbon-estimation-table.component.spec.ts
@@ -38,6 +38,7 @@ describe('CarbonEstimationTableComponent', () => {
       downstreamEmissions: {
         endUser: 13,
         networkTransfer: 12,
+        downstreamInfrastructure: 0
       },
     };
 

--- a/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.spec.ts
+++ b/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.spec.ts
@@ -36,6 +36,7 @@ describe('CarbonEstimationTreemapComponent', () => {
       downstreamEmissions: {
         endUser: 13,
         networkTransfer: 12,
+        downstreamInfrastructure: 0
       },
     };
 
@@ -164,6 +165,7 @@ describe('CarbonEstimationTreemapComponent', () => {
       downstreamEmissions: {
         endUser: 13,
         networkTransfer: 12,
+        downstreamInfrastructure: 0
       },
     };
     fixture.componentRef.setInput('carbonEstimation', carbonEstimation);
@@ -195,6 +197,7 @@ describe('CarbonEstimationTreemapComponent', () => {
       downstreamEmissions: {
         endUser: 25,
         networkTransfer: 0,
+        downstreamInfrastructure: 0
       },
     };
     fixture.componentRef.setInput('carbonEstimation', carbonEstimation);
@@ -273,6 +276,7 @@ describe('CarbonEstimationTreemapComponent', () => {
       downstreamEmissions: {
         endUser: 0,
         networkTransfer: 0,
+        downstreamInfrastructure: 0
       },
     };
     fixture.componentRef.setInput('carbonEstimation', carbonEstimation);

--- a/src/app/carbon-estimation/carbon-estimation.component.spec.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.spec.ts
@@ -38,6 +38,7 @@ describe('CarbonEstimationComponent', () => {
       downstreamEmissions: {
         endUser: 13,
         networkTransfer: 12,
+        downstreamInfrastructure: 0
       },
     };
 

--- a/src/app/estimation/estimate-downstream-emissions.spec.ts
+++ b/src/app/estimation/estimate-downstream-emissions.spec.ts
@@ -16,6 +16,7 @@ describe('estimateDownstreamEmissions()', () => {
     expect(estimateDownstreamEmissions(input, carbonIntensity)).toEqual({
       endUser: 0,
       networkTransfer: 0,
+      downstreamInfrastructure: 0
     });
   });
 
@@ -36,27 +37,27 @@ describe('estimateDownstreamEmissions()', () => {
 
   it('should return emissions for information site', () => {
     const result = estimateDownstreamEmissions(createInput('information'), carbonIntensity);
-    expectEmissionsCloseTo(result, { endUser: 0.51, networkTransfer: 0.05 });
+    expectEmissionsCloseTo(result, { endUser: 0.51, networkTransfer: 0.05, downstreamInfrastructure: 0 });
   });
 
   it('should return emissions for e-commerce site', () => {
     const result = estimateDownstreamEmissions(createInput('eCommerce'), carbonIntensity);
-    expectEmissionsCloseTo(result, { endUser: 3.18, networkTransfer: 1.07 });
+    expectEmissionsCloseTo(result, { endUser: 3.18, networkTransfer: 1.07, downstreamInfrastructure: 0});
   });
 
   it('should return emissions for social media site', () => {
     const result = estimateDownstreamEmissions(createInput('socialMedia'), carbonIntensity);
-    expectEmissionsCloseTo(result, { endUser: 517.851, networkTransfer: 286.09 });
+    expectEmissionsCloseTo(result, { endUser: 517.851, networkTransfer: 286.09, downstreamInfrastructure: 0 });
   });
 
   it('should return emissions for streaming site', () => {
     const result = estimateDownstreamEmissions(createInput('streaming'), carbonIntensity);
-    expectEmissionsCloseTo(result, { endUser: 703.48, networkTransfer: 668.91 });
+    expectEmissionsCloseTo(result, { endUser: 703.48, networkTransfer: 668.91, downstreamInfrastructure: 0 });
   });
 
   it('should return emissions based on average values', () => {
     const result = estimateDownstreamEmissions(createInput('average'), carbonIntensity);
-    expectEmissionsCloseTo(result, { endUser: 306.25, networkTransfer: 239.03 });
+    expectEmissionsCloseTo(result, { endUser: 306.25, networkTransfer: 239.03, downstreamInfrastructure: 0 });
   });
 
   it('should create average equivalent to average of all other purposes', () => {

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -121,9 +121,5 @@ function estimateDownstreamInfrastructureEmissions(
   downstream: Downstream, 
   downstreamDataTransfer: number,
   downstreamIntensity: gCo2ePerKwh) {
-  return 1000;
-
-
-  const usageTime = siteTypeInfo[downstream.purposeOfSite].averageMonthlyUserData * 12;
-  const endUserEnergy = estimateEndUserEnergy(downstreamDataTransfer, endUserTime, downstream.mobilePercentage);
+  return 0; //No method for estimation of IoT devices, etc. as of 12/08/25 for schema v0.0.2
 }

--- a/src/app/estimation/estimate-downstream-emissions.ts
+++ b/src/app/estimation/estimate-downstream-emissions.ts
@@ -59,7 +59,7 @@ export function estimateDownstreamEmissions(
   downstreamIntensity: gCo2ePerKwh
 ): DownstreamEstimation {
   if (downstream.noDownstream) {
-    return { endUser: 0, networkTransfer: 0 };
+    return { endUser: 0, networkTransfer: 0, downstreamInfrastructure: 0 };
   }
 
   const downstreamDataTransfer = estimateDownstreamDataTransfer(
@@ -68,7 +68,8 @@ export function estimateDownstreamEmissions(
   );
   const endUserEmissions = estimateEndUserEmissions(downstream, downstreamDataTransfer, downstreamIntensity);
   const networkEmissions = estimateNetworkEmissions(downstream, downstreamDataTransfer);
-  return { endUser: endUserEmissions, networkTransfer: networkEmissions };
+  const downstreamInfrastructureEmissions = estimateDownstreamInfrastructureEmissions(downstream, downstreamDataTransfer, downstreamIntensity);
+  return { endUser: endUserEmissions, networkTransfer: networkEmissions, downstreamInfrastructure: downstreamInfrastructureEmissions };
 }
 
 function estimateDownstreamDataTransfer(monthlyActiveUsers: number, purposeOfSite: PurposeOfSite): Gb {
@@ -114,4 +115,15 @@ function estimateNetworkEmissions(downstream: Downstream, downstreamDataTransfer
     return result.co2.networkCO2 / 1000;
   }
   throw new Error('perByteTrace should return CO2EstimateComponents for segment results');
+}
+
+function estimateDownstreamInfrastructureEmissions(
+  downstream: Downstream, 
+  downstreamDataTransfer: number,
+  downstreamIntensity: gCo2ePerKwh) {
+  return 1000;
+
+
+  const usageTime = siteTypeInfo[downstream.purposeOfSite].averageMonthlyUserData * 12;
+  const endUserEnergy = estimateEndUserEnergy(downstreamDataTransfer, endUserTime, downstream.mobilePercentage);
 }

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.spec.ts
@@ -26,6 +26,7 @@ const getMockCarbonEstimation: () => CarbonEstimation = () => ({
   downstreamEmissions: {
     endUser: 15,
     networkTransfer: 10,
+    downstreamInfrastructure: 0
   },
 });
 

--- a/src/app/types/carbon-estimator.ts
+++ b/src/app/types/carbon-estimator.ts
@@ -28,6 +28,7 @@ export type DirectEstimation = {
 export type DownstreamEstimation = {
   endUser: number;
   networkTransfer: number;
+  downstreamInfrastructure: number;
 };
 
 export type EstimatorValues = {


### PR DESCRIPTION
## Description of Change

- Adds a new `downstreamInfrastructure` to the `downstreamEmissions` type to match schema v0.0.2
- Updates tests to default the property value
- Adds function stub for later updates when calculation method available

## Checklist

- [x] tests are updated or added
