### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -6,6 +6,8 @@ concurrency:
   cancel-in-progress: false
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/buildAndTest.yml
 
   publish:


### PR DESCRIPTION
Potential fix for [https://github.com/ScottLogic/sl-tech-carbon-estimator/security/code-scanning/5](https://github.com/ScottLogic/sl-tech-carbon-estimator/security/code-scanning/5)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/publish-package.yml`. This block should specify the minimal permissions required for the job. Since the job is named `test` and likely only runs tests (as implied by its name and the fact that it uses a build-and-test workflow), it probably only needs read access to the repository contents. Therefore, set `permissions: contents: read` for the `test` job. This change should be made directly under the `test:` job definition, at the same indentation level as `uses:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
