### PR TITLE
totals colour changed from orange to neutral on chart and table in li…

### DIFF
--- a/src/app/carbon-estimation/carbon-estimation.constants.ts
+++ b/src/app/carbon-estimation/carbon-estimation.constants.ts
@@ -8,7 +8,7 @@ export enum EmissionsColours {
   OperationLight = '#f2afd1',
   Downstream = '#4B7E56',
   DownstreamLight = '#c1d9c3',
-  Total = '#FA8904',
+  Total = '#646464',
 }
 
 export enum PlaceholderEmissionsColours {

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,7 +47,7 @@ input.ng-invalid.ng-touched {
 }
 
 .tce-chart-total-colour {
-  @apply tce:bg-orange-400 tce:h-[16px] tce:w-[16px] tce:rounded-full tce:mr-1 tce:inline-block tce:border-2 tce:border-white;
+  @apply tce:bg-neutral-500 tce:h-[16px] tce:w-[16px] tce:rounded-full tce:mr-1 tce:inline-block tce:border-2 tce:border-white;
 }
 
 .tce-switch-container {


### PR DESCRIPTION
…ne with accedibility requirements


Resolves #&lt;Issue number&gt;
bug 204 table contrast for totals is insufficient


## Description of Change
current orange background with white text not accessible
suggested change was to background rgb(100 100 100)
Table colours are # so this maps to #646464
Chart key (changed for consistency) uses Tailwind, closest is neutral-500 (oklch(55 0 0) vs target oklch(50 0 0))

