### PR TITLE
#198 Bugfix for dropdown contrast in dark mode

### DIFF
--- a/src/app/carbon-estimator-form/carbon-estimator-form.component.html
+++ b/src/app/carbon-estimator-form/carbon-estimator-form.component.html
@@ -11,7 +11,7 @@
         <label class="tce:text-sm" for="headCount">How many employees are in the organisation? </label>
         <input
           id="headCount"
-          class="tce:border tce:border-slate-400 tce:rounded-sm"
+          class="tce-input"
           formControlName="headCount"
           name="headCount"
           type="number"
@@ -78,7 +78,7 @@
         <label class="tce:text-sm" for="numberOfServers">Number of Servers:</label>
         <input
           id="numberOfServers"
-          class="tce:border tce:border-slate-400 tce:rounded-sm tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed"
+          class="tce-input tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed"
           formControlName="numberOfServers"
           name="numberOfServers"
           type="number"
@@ -142,7 +142,7 @@
           <label for="monthlyCloudBill" class="tce:text-sm">What is your monthly cloud bill?</label>
           <select
             id="monthlyCloudBill"
-            class="tce:border tce:border-slate-400 tce:rounded-sm tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed tce:px-3 tce:py-2"
+            class="tce-select tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed"
             formControlName="monthlyCloudBill"
             name="monthlyCloudBill"
             required
@@ -189,7 +189,7 @@
             </div>
           </expansion-panel>
           <select
-            class="tce:border tce:border-slate-400 tce:rounded-sm"
+            class="tce-select"
             formControlName="purposeOfSite"
             name="purposeOfSite"
             id="purposeOfSite">
@@ -207,7 +207,7 @@
             How many monthly active users do your digital services have?
           </label>
           <input
-            class="tce:border tce:border-slate-400 tce:rounded-sm"
+            class="tce-input"
             formControlName="monthlyActiveUsers"
             name="monthlyActiveUsers"
             type="number"
@@ -295,7 +295,7 @@
         </div>
       </expansion-panel>
       <select
-        class="tce:border tce:border-slate-400 tce:rounded-sm tce:px-3 tce:py-2"
+        class="tce-select"
         name="{{ formControlName }}"
         formControlName="{{ formControlName }}"
         id="{{ formControlName }}">

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,3 +69,11 @@ input.ng-invalid.ng-touched {
 .tce-no-ex-table-header {
   @apply tce:pl-3 tce:h-8;
 }
+
+.tce-select, .tce-input {
+  @apply tce:border tce:border-slate-400 tce:rounded-sm tce:px-3 tce:py-2
+}
+
+.tce-select > option {
+  @apply tce:dark:bg-slate-800 tce:dark:text-slate-50
+}


### PR DESCRIPTION
### Description of Change

- Added custom styles `tce-select` and `tce-input` which provide a consistent look to inputs in light or dark mode.
- `tce-select > option` correctly styles option values for dark mode

<img width="930" height="340" alt="image" src="https://github.com/user-attachments/assets/c3a1bb8c-a20f-496c-b3d1-83b4b3daf2b2" />
