### PR TITLE
Fix bug with diagram disappearing

### DIFF
--- a/src/app/tab/tab-item/tab-item.component.html
+++ b/src/app/tab/tab-item/tab-item.component.html
@@ -1,3 +1,3 @@
-<div [hidden]="!active()">
+<div role="tabpanel" [hidden]="!active()">
   <ng-content></ng-content>
 </div>

--- a/src/app/tab/tabs/tabs.component.html
+++ b/src/app/tab/tabs/tabs.component.html
@@ -11,6 +11,4 @@
     </div>
   }
 </div>
-<div role="tabpanel">
-  <ng-content></ng-content>
-</div>
+<ng-content></ng-content>


### PR DESCRIPTION
Issue #208

## Description of Change

Diagram is shown again after size/data modified while hidden, have changed tab items to contain a conditionally hidden `<div>` instead of removing contents completely. See note in https://angular.dev/guide/components/content-projection that `<ng-content>` should not be conditionally included generally. Plus, in the case of Apexcharts, its component doesn't go through the normal Lifecycle and its underlying DOM element gets disconnected, causing errors.

No visual difference but inspection now shows tab contents as always present and conditionally hidden:

<img width="605" height="229" alt="image" src="https://github.com/user-attachments/assets/487b3d9d-6573-4942-afdd-34b13b594c46" />


