### PR TITLE
Alternative fix for bug with diagram disappearing

### DIFF
--- a/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.html
+++ b/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.html
@@ -33,6 +33,5 @@
     [legend]="chartOptions().legend"
     [states]="chartOptions().states"
     [dataLabels]="chartOptions().dataLabels"
-    [tooltip]="chartOptions().tooltip"
-    (chartReady)="onChartReady()"></apx-chart>
+    [tooltip]="chartOptions().tooltip"></apx-chart>
 </figure>

--- a/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.ts
+++ b/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.ts
@@ -37,9 +37,6 @@ export class CarbonEstimationTreemapComponent {
 
   public chartOptions = computed(() => this.getChartOptions(!this.carbonEstimation()));
 
-  // private tooltipFormatter = tooltipFormatter;
-  private chartReady = false;
-
   @ViewChild('chart') private chart: ChartComponent | undefined;
 
   constructor(private carbonEstimationUtilService: CarbonEstimationUtilService) {
@@ -60,18 +57,6 @@ export class CarbonEstimationTreemapComponent {
     this.isMass.update(value => !value);
     // this.getChartData(this.carbonEstimation());
   };
-
-  public onChartReady() {
-    this.chartReady = true;
-  }
-
-  public readyChart(): ChartComponent | undefined {
-    if (this.chartReady) {
-      return this.chart;
-    }
-
-    return undefined;
-  }
 
   private getChartOptions(isPlaceholder: boolean) {
     const chartOptions = getBaseChartOptions(isPlaceholder, this.isMass());

--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -31,11 +31,14 @@
     </div>
   </expansion-panel>
   <tabs class="tce:mt-2">
-    <tab-item [active]="true" [title]="'Diagram'" (tabSelected)="treemapSelected()">
-      <carbon-estimation-treemap
-        #treemap
-        [carbonEstimation]="carbonEstimation()"
-        [chartHeight]="chartHeight"></carbon-estimation-treemap>
+    <tab-item [(active)]="diagramActive" [title]="'Diagram'">
+      <!-- Apex chart does not get destroyed correctly if it exists when tab is inactive -->
+      @if (diagramActive())
+      {
+        <carbon-estimation-treemap
+          [carbonEstimation]="carbonEstimation()"
+          [chartHeight]="chartHeight"></carbon-estimation-treemap>
+      }
     </tab-item>
     <tab-item [title]="'Table'">
       <carbon-estimation-table [carbonEstimation]="carbonEstimation()"></carbon-estimation-table

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, effect, ElementRef, input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, effect, ElementRef, input, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.component';
 import { TabsComponent } from '../tab/tabs/tabs.component';
 import { TabItemComponent } from '../tab/tab-item/tab-item.component';
@@ -28,8 +28,9 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   public carbonEstimation = input<CarbonEstimation>();
   public extraHeight = input<string>();
 
+  public diagramActive = signal(true);
+
   @ViewChild('detailsPanel', { static: true, read: ElementRef }) detailsPanel!: ElementRef;
-  @ViewChild('treemap', { static: true }) treemap!: CarbonEstimationTreemapComponent;
 
   public chartHeight!: number;
 
@@ -65,15 +66,6 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   public onExpanded(): void {
     this.changeDetectorRef.detectChanges();
     this.onResize(window.innerHeight, window.innerWidth, window.screen.height);
-  }
-
-  public treemapSelected(): void {
-    if (this.hasResized || this.hasEstimationUpdated) {
-      this.hasResized = false;
-      this.hasEstimationUpdated = false;
-      this.changeDetectorRef.detectChanges();
-      this.treemap.readyChart()?.updateOptions({});
-    }
   }
 
   private getChartHeight(innerHeight: number, innerWidth: number, screenHeight: number): number {

--- a/src/app/tab/tab-item/tab-item.component.ts
+++ b/src/app/tab/tab-item/tab-item.component.ts
@@ -10,13 +10,4 @@ import { Component, effect, EventEmitter, input, model, Output } from '@angular/
 export class TabItemComponent {
   public active = model(false);
   public title = input.required<string>();
-  @Output() public tabSelected = new EventEmitter<void>();
-
-  constructor() {
-    effect(() => {
-      if (this.active()) {
-        this.tabSelected.emit();
-      }
-    });
-  }
 }


### PR DESCRIPTION
Issue #208

## Description of Change

Diagram is shown again after size/data modified while hidden:

- Changed estimation component so that treemap doesn't exist when tab not active, ensures it goes through lifecycle correctly
- Removed a lot of code triggered when diagram tab becomes active, which is no longer necessary