### PR TITLE
fix updated tooltip and assumption text to mention raw data #251

### DIFF
--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.html
@@ -25,7 +25,7 @@
     </li>
   </ul>
   <p class="tce:text-sm">
-    The optional monthly view shows the KgCO<sub>2</sub>e divided by 12 to give an average monthly figure.
+    The optional monthly view shows the raw Annual KgCO<sub>2</sub>e divided by 12 to give an average monthly figure.
   </p>
   <p class="tce:text-sm">
     Obviously, this may not match up with your organisation's usage, either due to different working hours or whether

--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -93,7 +93,7 @@
 
       <button
         aria-describedby="annualMonthlyInfo"
-        title="Monthly = annual ÷ 12"
+        title="Monthly = raw Annual ÷ 12"
         class="tce:size-[44px] tce:flex tce:items-center tce:justify-center"
       >
 


### PR DESCRIPTION
text change to annual/monthly switch and assumptions text to show that monthly figures are calculated from the raw annual figure
