### PR TITLE
ci: add linting as pipeline check

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    # branches:
-    #   - main
-    #   - develop
-    #   - 'release/**'
+    branches:
+      - main
+      - develop
+      - 'release/**'
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
+++ b/src/app/assumptions-and-limitation/assumptions-and-limitation.component.ts
@@ -6,7 +6,6 @@ import { DecimalPipe } from '@angular/common';
 import { CarbonIntensityService } from '../services/carbon-intensity.service';
 import { desktop, laptop, mobile, monitor, network, server, tablet } from '../estimation/device-type';
 import { ExternalLinkDirective } from '../directives/external-link.directive';
-import { TestBed } from '@angular/core/testing';
 
 const purposeDescriptions: Record<PurposeOfSite, string> = {
   information: 'Information',
@@ -72,7 +71,7 @@ export class AssumptionsAndLimitationComponent {
     },
   ];
 
-  constructor(test: TestBed) {
+  constructor() {
     this.siteTypeInfo = purposeOfSiteArray.map(purpose => ({
       type: purposeDescriptions[purpose],
       time: this.downstreamEstimator.siteTypeInfo[purpose].averageMonthlyUserTime,


### PR DESCRIPTION
Adds the `lint:` step to the `buildAndTest.yml` Actions workflow file.

Lint check is run before build and test, and has been added to the `needs:` property of `build` to prevent build and test from running if there are linting errors.

See [this action run](https://github.com/ScottLogic/sl-tech-carbon-estimator/actions/runs/19709607892/job/56466296101) for an example of a linting failure in the pipeline

Currently this allows eslint warnings, but can be changed if we want to disallow warnings.

Branch protection will need to be enabled after the merge to enforce lint check success for PR merges, but this behaviour is also currently replicated by the build and test steps requiring lint checks to succeed before they run.