### PR TITLE
fix(lint): use npm run lint script in pipeline

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/set-up-environment
       - name: Run ESLint
-        run: npx eslint .
+        run: npm run lint
   build:
     needs: lint
     runs-on: ubuntu-latest

--- a/angular.json
+++ b/angular.json
@@ -129,7 +129,8 @@
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"],
+            "eslintConfig": "eslint.config.mjs"
           }
         }
       }


### PR DESCRIPTION
Ensures the pipeline uses the eslint binary installed locally in the node_modules directory, and as a side-effect makes use of `ng lint` to incorporate angular-specific concerns, rules, and schemas into the linting process.