### PR TITLE
fix: resolve accessibility-related linting errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,11 @@ export default defineConfig([
   },
   {
     files: ['**/*.html'],
-    extends: compat.extends('plugin:@angular-eslint/template/recommended', 'plugin:prettier/recommended'),
+    extends: compat.extends(
+      'plugin:@angular-eslint/template/recommended',
+      'plugin:prettier/recommended',
+      'plugin:@angular-eslint/template/accessibility'
+    ),
     rules: {
       'prettier/prettier': [
         'error',

--- a/src/app/carbon-estimation-table/carbon-estimation-table.component.html
+++ b/src/app/carbon-estimation-table/carbon-estimation-table.component.html
@@ -8,6 +8,7 @@
   </thead>
   @if (tableData().length > 0) {
     <tbody
+      tabindex="0"
       (keydown.home)="homeEndKeyBoardEvent($event)"
       (keydown.end)="homeEndKeyBoardEvent($event)"
       (keydown.control.home)="homeEndKeyBoardEvent($event)"

--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -43,6 +43,8 @@
       </button>
 
       @if (isExportMenuOpen) {
+        <!-- disabling accessibility linting for the following div because it's only supposed to stop click event propagation up the DOM and not actually be clicked or focussed -->
+        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
         <div
           class="tce:top-full tce:left-0 tce-mt-2 tce:bg-white tce:shadow-lg tce:rounded tce:z-50"
           (click)="$event.stopPropagation()">

--- a/src/app/export-modal/export-modal.component.html
+++ b/src/app/export-modal/export-modal.component.html
@@ -1,4 +1,6 @@
-<div class="tce-export-modal-overlay" (click)="closeModal()">
+<div class="tce-export-modal-overlay" (click)="closeModal()" (keydown.escape)="closeModal()" tabindex="0">
+  <!-- disabling accessibility linting for the following div because it's only supposed to stop click event propagation up the DOM and not actually be clicked or focussed -->
+  <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
   <div class="tce-export-modal-content" (click)="$event.stopPropagation()">
     <div class="tce:mb-2">
       <label

--- a/src/app/export-modal/export-modal.component.html
+++ b/src/app/export-modal/export-modal.component.html
@@ -1,7 +1,7 @@
 <div class="tce-export-modal-overlay" (click)="closeModal()" (keydown.escape)="closeModal()" tabindex="0">
   <!-- disabling accessibility linting for the following div because it's only supposed to stop click event propagation up the DOM and not actually be clicked or focussed -->
   <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
-  <div class="tce-export-modal-content" (click)="$event.stopPropagation()">
+  <div class="tce-export-modal-content" (click)="$event.stopPropagation()" cdkTrapFocus cdkTrapFocusAutoCapture>
     <div class="tce:mb-2">
       <label
         >Report Name:

--- a/src/app/export-modal/export-modal.component.ts
+++ b/src/app/export-modal/export-modal.component.ts
@@ -5,6 +5,7 @@ import { CarbonEstimation, EstimatorValues } from '../types/carbon-estimator';
 import { FormsModule } from '@angular/forms';
 import { InputGroupDisplay } from '../input-group-display/input-group-display.component';
 import { DisclaimerTextComponent } from '../disclaimer-text/disclaimer-text.component';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @Component({
   selector: 'export-modal',
@@ -15,6 +16,7 @@ import { DisclaimerTextComponent } from '../disclaimer-text/disclaimer-text.comp
     FormsModule,
     InputGroupDisplay,
     DisclaimerTextComponent,
+    A11yModule,
   ],
 })
 export class ExportModal {


### PR DESCRIPTION
Resolves #295 

Fixes several issues related to accessibility:
- Added accessibility plugin into linting config `eslint.config.mjs`
- Added `tabindex` attribute to `tbody` element of `src/app/carbon-estimation-table/carbon-estimation-table.component.html`
  - Resolves: `Elements with interaction handlers must be focusable. eslint@angular-eslint/template/interactive-supports-focus`
- Added `eslint-disable-next-line` comments above elements that contain the `(click)="$event.stopPropagation()"` event binding
  - The `stopPropagation` method prevents click events on child elements from propagating up the DOM
  - The fact that the `(click)` event handler is present without a keyboard alternative and a `tabindex` attribute triggers these accessibility lint errors:
    - `@angular-eslint/template/click-events-have-key-events`
    - `@angular-eslint/template/interactive-supports-focus`
  - The accessibility linting plugin is simply checking for the presence of any `(click)` event binding on an element that doesn't have a keyboard alternative, and `stopPropagation` isn't a event method that does anything on-click, hence excluding it from the linting
- Used A11yModule to implement focus-trapping on the export modal to ensure that, whilst the modal is open, using `tab` to navigate will keep focus within the modal