### PR TITLE
fix(modal): resolve host app elements obscuring export modal

### DIFF
--- a/src/app/carbon-estimation/carbon-estimation.component.html
+++ b/src/app/carbon-estimation/carbon-estimation.component.html
@@ -133,7 +133,4 @@
       <carbon-estimation-table [carbonEstimation]="estimate()" [shouldShowSvgs]="true"></carbon-estimation-table
     ></tab-item>
   </tabs>
-  @if (isModalVisible) {
-    <export-modal (closePreview)="hideModal()" [carbonEstimation]="estimate()" [inputValues]="inputValues()" />
-  }
 </div>

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -21,8 +21,8 @@ import { estimatorHeights } from './carbon-estimation.constants';
 import { debounceTime, fromEvent, Subscription } from 'rxjs';
 import { CarbonEstimationTableComponent } from '../carbon-estimation-table/carbon-estimation-table.component';
 import { ExternalLinkDirective } from '../directives/external-link.directive';
-import { ExportModal } from '../export-modal/export-modal.component';
 import { CommonModule } from '@angular/common';
+import { Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'carbon-estimation',
@@ -35,7 +35,6 @@ import { CommonModule } from '@angular/common';
     CarbonEstimationTreemapComponent,
     CarbonEstimationTableComponent,
     ExternalLinkDirective,
-    ExportModal,
   ],
   templateUrl: './carbon-estimation.component.html',
   styleUrls: ['./carbon-estimation.component.css'],
@@ -62,6 +61,11 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   public estimate = computed(() => (this.isAnnual() ? this.carbonEstimation() : this.monthlyCarbonEstimation()));
 
   private changeDetectorRef = inject(ChangeDetectorRef);
+
+  @Output() public pdfExportClicked = new EventEmitter<{
+    estimation: CarbonEstimation;
+    inputValues: EstimatorValues | undefined;
+  }>();
 
   constructor() {
     effect(() => {
@@ -157,7 +161,11 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
   public handlePDFClick() {
     this.toggleExportMenu();
-    this.showModal();
+
+    this.pdfExportClicked.emit({
+      estimation: this.estimate() as CarbonEstimation,
+      inputValues: this.inputValues(),
+    });
   }
 
   private getMonthlyEstimate(): CarbonEstimation | undefined {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -8,6 +8,7 @@ import {
   input,
   OnDestroy,
   OnInit,
+  output,
   signal,
   ViewChild,
 } from '@angular/core';
@@ -22,7 +23,6 @@ import { debounceTime, fromEvent, Subscription } from 'rxjs';
 import { CarbonEstimationTableComponent } from '../carbon-estimation-table/carbon-estimation-table.component';
 import { ExternalLinkDirective } from '../directives/external-link.directive';
 import { CommonModule } from '@angular/common';
-import { Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'carbon-estimation',
@@ -62,7 +62,7 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
 
   private changeDetectorRef = inject(ChangeDetectorRef);
 
-  @Output() public pdfExportClicked = new EventEmitter<{
+  public pdfExportClicked = output<{
     estimation: CarbonEstimation;
     inputValues: EstimatorValues | undefined;
   }>();

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.html
@@ -1,6 +1,7 @@
 <div
   id="techCarbonEstimator"
-  class="tce:p-4 tce:flex tce:flex-col tce:h-full tce:dark:bg-slate-800 tce:dark:text-slate-50">
+  class="tce:relative tce:p-4 tce:flex tce:flex-col tce:h-full tce:dark:bg-slate-800 tce:dark:text-slate-50"
+  [class.tce-no-scroll]="isExportModalVisible">
   <h1 class="tce:text-3xl tce:mb-6">Technology Carbon Estimator</h1>
   <div class="tce:flex tce:w-full tce:grow tce:flex-wrap tce:lg:flex-nowrap">
     <div class="tce:w-full tce:lg:w-1/2 tce:pb-4 tce:lg:pb-0 tce:lg:pr-4">
@@ -23,7 +24,15 @@
       <carbon-estimation
         [carbonEstimation]="carbonEstimation ? carbonEstimation : undefined"
         [extraHeight]="extraHeight"
-        [inputValues]="formValue"></carbon-estimation>
+        [inputValues]="formValue"
+        (pdfExportClicked)="openExportModal($event.estimation, $event.inputValues)">
+      </carbon-estimation>
     </div>
   </div>
+  @if (isExportModalVisible) {
+    <export-modal
+      (closePreview)="closeExportModal()"
+      [carbonEstimation]="modalCarbonEstimation === null ? undefined : modalCarbonEstimation"
+      [inputValues]="modalInputValues" />
+  }
 </div>

--- a/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
+++ b/src/app/tech-carbon-estimator/tech-carbon-estimator.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  HostBinding,
   Input,
   OnInit,
   ViewChild,
@@ -18,6 +19,7 @@ import { AssumptionsAndLimitationComponent } from '../assumptions-and-limitation
 import { DisclaimerComponent } from '../disclaimer/disclaimer.component';
 import { TabsComponent } from '../tab/tabs/tabs.component';
 import { TabItemComponent } from '../tab/tab-item/tab-item.component';
+import { ExportModal } from '../export-modal/export-modal.component';
 
 @Component({
   selector: 'tech-carbon-estimator',
@@ -31,6 +33,7 @@ import { TabItemComponent } from '../tab/tab-item/tab-item.component';
     DisclaimerComponent,
     TabsComponent,
     TabItemComponent,
+    ExportModal,
   ],
   templateUrl: './tech-carbon-estimator.component.html',
 
@@ -38,6 +41,8 @@ import { TabItemComponent } from '../tab/tab-item/tab-item.component';
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class TechCarbonEstimatorComponent implements OnInit {
+  @HostBinding('style.position') position = 'relative';
+
   private estimationService = inject(CarbonEstimationService);
   private changeDetector = inject(ChangeDetectorRef);
   private ref = inject(ElementRef);
@@ -49,6 +54,20 @@ export class TechCarbonEstimatorComponent implements OnInit {
   public carbonEstimation: CarbonEstimation | null = null;
 
   @ViewChild('estimations') estimations!: ElementRef;
+
+  public isExportModalVisible = false;
+  public modalCarbonEstimation: CarbonEstimation | null = null;
+  public modalInputValues: EstimatorValues | undefined;
+
+  public openExportModal(estimation: CarbonEstimation, inputValues: EstimatorValues | undefined) {
+    this.modalCarbonEstimation = estimation;
+    this.modalInputValues = inputValues;
+    this.isExportModalVisible = true;
+  }
+
+  public closeExportModal() {
+    this.isExportModalVisible = false;
+  }
 
   ngOnInit() {
     this.insertShadowStylesLink();

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,7 +91,7 @@ input.ng-invalid.ng-touched {
 }
 
 .tce-export-modal-content {
-  @apply tce:text-slate-950 tce:bg-slate-300 tce:rounded-lg tce:px-8;
+  @apply tce:text-slate-950 tce:bg-slate-300 tce:rounded-lg tce:px-8 tce:mt-32 tce:mb-32;
 }
 
 .tce-export-modal-export-area-colour-provider {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-@import "tailwindcss" prefix(tce);
+@import 'tailwindcss' prefix(tce);
 
 @theme {
   --font-display: 'objektiv-mk1', 'sans-serif';
@@ -35,7 +35,8 @@ input.ng-invalid.ng-touched {
   @apply tce:bg-slate-200 tce:text-slate-800 tce:hover:bg-slate-300 tce:rounded-sm;
 }
 
-.tce-active-tab, .tce-active-tab:hover {
+.tce-active-tab,
+.tce-active-tab:hover {
   @apply tce:cursor-default tce:border-sky-800;
 }
 
@@ -81,8 +82,12 @@ input.ng-invalid.ng-touched {
   @apply tce:pl-3 tce:h-8;
 }
 
+.tce-no-scroll {
+  @apply tce:overflow-hidden tce:max-h-svh;
+}
+
 .tce-export-modal-overlay {
-  @apply tce:fixed tce:top-0 tce:left-0 tce:w-full tce:h-full tce:bg-black/70 tce:flex tce:justify-center tce:items-start tce:overflow-auto;
+  @apply tce:absolute tce:top-0 tce:left-0 tce:w-full tce:h-full tce:bg-black/70 tce:flex tce:justify-center tce:items-start tce:overflow-scroll;
 }
 
 .tce-export-modal-content {
@@ -101,7 +106,7 @@ input.ng-invalid.ng-touched {
   @apply tce:!text-slate-950;
 }
 
-.tce-export-modal-content .apexcharts-legend-text{
+.tce-export-modal-content .apexcharts-legend-text {
   @apply tce:!text-slate-950;
 }
 
@@ -125,12 +130,13 @@ input.ng-invalid.ng-touched {
   @apply tce:grid tce:grid-cols-2 tce:grid-rows-2 tce:gap-4 tce:grid-flow-col;
 }
 
-.tce-select, .tce-input {
-  @apply tce:border tce:border-slate-400 tce:rounded-sm tce:px-3 tce:py-2
+.tce-select,
+.tce-input {
+  @apply tce:border tce:border-slate-400 tce:rounded-sm tce:px-3 tce:py-2;
 }
 
 .tce-select > option {
-  @apply tce:dark:bg-slate-800 tce:dark:text-slate-50
+  @apply tce:dark:bg-slate-800 tce:dark:text-slate-50;
 }
 
 .tce-export-button:disabled {
@@ -150,39 +156,39 @@ apx-chart .apexcharts-legend .apexcharts-legend-series:hover {
 }
 
 @media (prefers-color-scheme: dark) {
-    .apexcharts-legend-text {
-        --tw-text-opacity: 1 !important;
-        color: rgb(248 250 252 / var(--tw-text-opacity))!important;
-    }
-
-    input.ng-invalid.ng-touched {
-        --tw-border-opacity: 1;
-        border-color: rgb(185 28 28 / var(--tw-border-opacity))
-    }
-
-    .tce-error-box {
-        border-radius: .25rem;
-        border-width: 1px;
-        --tw-border-opacity: 1;
-        border-color: rgb(255 255 255 / var(--tw-border-opacity));
-        --tw-bg-opacity: 1;
-        background-color: rgb(185 28 28 / var(--tw-bg-opacity));
-        padding: .25rem;
-        --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity))
-    }
-
-    .tce-error-summary {
-        --tw-border-opacity: 1;
-        border-color: rgb(255 255 255 / var(--tw-border-opacity));
-        --tw-bg-opacity: 1;
-        background-color: rgb(185 28 28 / var(--tw-bg-opacity));
-        --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity))
-    }
-
-    .tce-error-summary-link {
-        --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity))
-    }
+  .apexcharts-legend-text {
+    --tw-text-opacity: 1 !important;
+    color: rgb(248 250 252 / var(--tw-text-opacity)) !important;
   }
+
+  input.ng-invalid.ng-touched {
+    --tw-border-opacity: 1;
+    border-color: rgb(185 28 28 / var(--tw-border-opacity));
+  }
+
+  .tce-error-box {
+    border-radius: 0.25rem;
+    border-width: 1px;
+    --tw-border-opacity: 1;
+    border-color: rgb(255 255 255 / var(--tw-border-opacity));
+    --tw-bg-opacity: 1;
+    background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+    padding: 0.25rem;
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity));
+  }
+
+  .tce-error-summary {
+    --tw-border-opacity: 1;
+    border-color: rgb(255 255 255 / var(--tw-border-opacity));
+    --tw-bg-opacity: 1;
+    background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity));
+  }
+
+  .tce-error-summary-link {
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity));
+  }
+}


### PR DESCRIPTION
Fixes the modal being obscured by the [Tech Carbon Standard](https://www.techcarbonstandard.org/estimator) navbar, and prevents this issue from occurring in any other potential host app, by resizing the export modal to fill the space of the component only, instead of filling the entire viewport space (see screenshots).
This required additional changes:
- The export modal element was moved to the root component in the project
- The scroll behaviour of the root element was adjusted to ensure that only the export modal will scroll when it is open

### Before:
<img width="1670" height="1003" alt="image" src="https://github.com/user-attachments/assets/bf5287ca-7d0d-409f-8b24-572eaf5901d6" />

### After:
<img width="1667" height="1000" alt="image" src="https://github.com/user-attachments/assets/ce68652e-d2b3-42a9-a3ba-5afbb8f97715" />


- Applied auto-formatting to src/styles.css
