### PR TITLE
243: Update documentation around new SaaS components

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -68,3 +68,14 @@ Displays disclaimer about how the tool should be used.
 ## ExpansionPanelComponent
 
 Displays explanatory text that can be hidden if desired.
+
+## CloudFormSectionComponent
+
+Allows input of cloud based usage
+
+## SaaSFormSectionComponent
+
+Allows input of SaaS usage
+
+### Microsoft365FormSectionComponent
+Allows input of SaaS specific to Microsoft 365

--- a/docs/estimation.md
+++ b/docs/estimation.md
@@ -18,15 +18,26 @@ classDiagram
 
     class estimate-indirect-emissions{
       <<module>>
-      +estimateIndirectEmissions(input: Cloud, intensity: gCo2ePerKwh) IndirectEstimation
+      +estimateIndirectEmissions(input: EstimatorValues) IndirectEstimation
     }
-
+    
     class estimate-downstream-emissions{
       <<module>>
       +siteTypeInfo: Record~PurposeOfSite, SiteInformation~
       +estimateDownstreamEmissions(downstream: Downstream, ...) DownstreamEstimation
     }
   }
+
+  
+    class estimate-cloud-emissions{
+      <<module>>
+      +estimateEmissions(input: Cloud) KgCo2e
+    }
+    
+    class estimate-saas-emissions{
+      <<module>>
+      +estimateEmissions(input: Saas) KgCo2e
+    }
 
   namespace supporting-modules{
     class device-usage {
@@ -57,6 +68,8 @@ classDiagram
 
   estimate-upstream-emissions ..> device-usage
   estimate-direct-emissions ..> device-usage
+  estimate-saas-emissions ..> estimate-indirect-emissions
+  estimate-cloud-emissions ..> estimate-indirect-emissions
   estimate-indirect-emissions ..> estimate-energy-emissions
   estimate-downstream-emissions ..> device-type
   estimate-downstream-emissions ..> estimate-energy-emissions
@@ -106,8 +119,7 @@ Estimate emissions from Indirect categories
 
 ##### Parameters
 
-`input:`[`Cloud`](types.md#estimatorvalues) - The inputs relevant to cloud.
-`intensity:`[`gCo2ePerKwh`](types.md#units) - The Carbon intensity of the cloud region.
+`input:`[`EstimatorValues`](types.md#estimatorvalues) - The inputs relevant to cloud and SaaS.
 
 ##### Returns
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -13,12 +13,15 @@ classDiagram
     upstream: Upstream
     onPremise: OnPremise
     cloud: Cloud
+    saas: SaaS
     downstream: Downstream
   }
+  
   EstimatorValues --> "upstream" Upstream
   EstimatorValues --> "onPremise" OnPremise
   EstimatorValues --> "cloud" Cloud
   EstimatorValues --> "downstream" Downstream
+  EstimatorValues --> "SaaS" Saas
 
   class OnPremise {
     estimateServerCount: boolean
@@ -84,6 +87,15 @@ classDiagram
     'average'
   }
   PurposeOfSite --|> BasePurposeOfSite
+  Saas --> Microsoft365
+  class Saas {
+    microsoft365: Microsoft365
+  }
+
+  class Microsoft365 {
+    useMicrosoft365: boolean
+    organisationUserCount: number
+  }
 ```
 
 This is the input data that the [CarbonEstimationService](services.md#carbonestimationservice) requires.


### PR DESCRIPTION
Add several components to allow the estimator to estimate some basic SaaS emissions. For now only emissions related to use of Microsoft365 and it's tools are included

Update documentation around changes

- [x] relevant documentation is updated or added
