### PR TITLE
319: Update export PDF to include SaaS input values

### DIFF
--- a/src/app/export-modal/export-modal.component.html
+++ b/src/app/export-modal/export-modal.component.html
@@ -33,6 +33,7 @@
           <input-group-display [inputGroup]="downstream()" [group]="'Downstream'"></input-group-display>
           <input-group-display [inputGroup]="onPremise()" [group]="'On Premise'"></input-group-display>
           <input-group-display [inputGroup]="cloud()" [group]="'Cloud'"></input-group-display>
+          <input-group-display [inputGroup]="saas()" [group]="'Saas'"></input-group-display>
         </div>
         <div class="tce:absolute tce:left-0 tce:bottom-0 tce:w-full tce:mb-5">
           <h2 class="tce:mb-1">Disclaimer</h2>

--- a/src/app/export-modal/export-modal.component.spec.ts
+++ b/src/app/export-modal/export-modal.component.spec.ts
@@ -62,6 +62,12 @@ describe('ExportModal', () => {
       cloudLocation: 'UK',
       noCloudServices: false,
     },
+    saas: {
+      microsoft365: {
+        useMicrosoft365: true,
+        organisationUserCount: 9,
+      },
+    },
   };
 
   beforeEach(async () => {

--- a/src/app/export-modal/export-modal.component.ts
+++ b/src/app/export-modal/export-modal.component.ts
@@ -32,6 +32,7 @@ export class ExportModal {
   public onPremise = computed(() => this.inputValues()?.onPremise ?? {});
   public downstream = computed(() => this.inputValues()?.downstream ?? {});
   public cloud = computed(() => this.inputValues()?.cloud ?? {});
+  public saas = computed(() => this.inputValues()?.saas ?? {});
 
   private dateMills = Date.now();
   private date = new Date(this.dateMills);

--- a/src/app/input-group-display/input-group-display.component.ts
+++ b/src/app/input-group-display/input-group-display.component.ts
@@ -37,7 +37,7 @@ export class InputGroupDisplay {
 
       entries.push(['No Cloud Services', (this.inputGroup() as Cloud).noCloudServices]);
     } else if (this.group() === 'Saas') {
-      entries.push(['Use Microsoft365', (this.inputGroup() as Saas).microsoft365.useMicrosoft365]);
+      entries.push(['Use Microsoft 365', (this.inputGroup() as Saas).microsoft365.useMicrosoft365]);
       entries.push(['Users', (this.inputGroup() as Saas).microsoft365.organisationUserCount]);
     } else {
       entries = Object.entries(this.inputGroup() ?? {});

--- a/src/app/input-group-display/input-group-display.component.ts
+++ b/src/app/input-group-display/input-group-display.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed, input } from '@angular/core';
 import { Cloud, Downstream, OnPremise, Upstream } from '../types/carbon-estimator';
+import { Saas } from '../features/saas/components/saas.constants';
 
 @Component({
   selector: 'input-group-display',
@@ -7,7 +8,7 @@ import { Cloud, Downstream, OnPremise, Upstream } from '../types/carbon-estimato
   templateUrl: './input-group-display.component.html',
 })
 export class InputGroupDisplay {
-  public inputGroup = input<Upstream | OnPremise | Cloud | Downstream | Record<string, never>>();
+  public inputGroup = input<Upstream | OnPremise | Cloud | Downstream | Saas | Record<string, never>>();
   public group = input<string>();
 
   public displayEntries = computed(() => {
@@ -35,6 +36,9 @@ export class InputGroupDisplay {
       entries.push(['Cloud Location', (this.inputGroup() as Cloud).cloudLocation]);
 
       entries.push(['No Cloud Services', (this.inputGroup() as Cloud).noCloudServices]);
+    } else if (this.group() === 'Saas') {
+      entries.push(['Use Microsoft365', (this.inputGroup() as Saas).microsoft365.useMicrosoft365]);
+      entries.push(['Users', (this.inputGroup() as Saas).microsoft365.organisationUserCount]);
     } else {
       entries = Object.entries(this.inputGroup() ?? {});
       entries.forEach(entry => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -127,7 +127,7 @@ input.ng-invalid.ng-touched {
 }
 
 .tce-export-modal-input-display-container {
-  @apply tce:grid tce:grid-cols-2 tce:grid-rows-2 tce:gap-4 tce:grid-flow-col;
+  @apply tce:grid tce:grid-cols-2 tce:grid-rows-2 tce:gap-4 tce:grid-flow-row;
 }
 
 .tce-select,


### PR DESCRIPTION
Resolves #319 

## Description of Change

- Adds SaaS values to second page of PDF export
- Updates second page styling to limit input value entries to two columns

_Screenshot:_
<img width="2293" height="1392" alt="image" src="https://github.com/user-attachments/assets/a36190ed-9418-41a0-b95e-d8ca06428ca7" />


## Checklist

- [x] tests are updated or added
- [ ] relevant documentation is updated or added
