### PR TITLE
269: Improve table icons

### DIFF
--- a/src/app/carbon-estimation-table/carbon-estimation-table.component.html
+++ b/src/app/carbon-estimation-table/carbon-estimation-table.component.html
@@ -59,7 +59,7 @@
             [attr.aria-level]="tableItem.level"
             [attr.aria-setsize]="tableItem.setSize"
             [attr.aria-posinset]="tableItem.positionInSet"
-            [style.background-color]="tableItem.colour.background"
+            [style.background-color]="tableItem.colour.background + rowOpacity($index)"
             (keydown.arrowright)="arrowKeyBoardEvent($event, 'right')"
             (keydown.arrowleft)="arrowKeyBoardEvent($event, 'left')"
             [class.tce:hidden]="!tableItem.display"

--- a/src/app/carbon-estimation-table/carbon-estimation-table.component.html
+++ b/src/app/carbon-estimation-table/carbon-estimation-table.component.html
@@ -67,7 +67,7 @@
             <td role="gridcell" tabindex="-1" class="tce:flex tce:ml-8">
               <div
                 *ngIf="shouldShowSvgs()"
-                class="tce:p-1 tce:flex tce:rounded-sm tce:mr-2"
+                class="tce:p-1 tce:flex tce:my-auto tce:rounded-sm tce:mr-2"
                 [style.background-color]="tableItem.colour.svg ?? tableItem.colour.background">
                 <div class="tce:m-auto tce:size-4 {{ tableItem.svg }}"></div>
               </div>

--- a/src/app/carbon-estimation-table/carbon-estimation-table.component.ts
+++ b/src/app/carbon-estimation-table/carbon-estimation-table.component.ts
@@ -330,4 +330,8 @@ export class CarbonEstimationTableComponent {
       level: 2,
     };
   }
+
+  rowOpacity(index: number): string {
+    return index % 2 === 0 ? 'E4' : 'FF';
+  }
 }


### PR DESCRIPTION
## Description of Change
Improve readability of tables by introducing slight colour variation for alternate rows
Ensure that table icons keep square aspect ratios

<img width="870" height="458" alt="image" src="https://github.com/user-attachments/assets/ee15d426-7f98-4ad9-b828-8dc4b00bab7f" />
