### PR TITLE
309: Update Export JSON to match schema structure more closely

### DIFF
--- a/playwright-tests/e2e/T20-export-tests.spec.ts
+++ b/playwright-tests/e2e/T20-export-tests.spec.ts
@@ -1,10 +1,5 @@
 import { test, expect } from '../utilities/fixtures';
-import {
-  createDefaultPercentagesJsonExport,
-  createDefaultInputJsonExport,
-  createDefaultValuesJsonExport,
-  pdfComparison,
-} from '../utilities/test-helpers';
+import { createDefaultJsonExport, createDefaultInputJsonExport, pdfComparison } from '../utilities/test-helpers';
 import * as TestData from '../utilities/test-data';
 
 test.describe('Download and read files', () => {
@@ -37,11 +32,9 @@ test.describe('Download and read files', () => {
     const downloadPath = await estimationsSection.downloadFile(page, 'Export JSON');
     const jsonParse = await estimationsSection.readJsonFileContent(downloadPath);
 
-    const expectedAnnualValuesJsonContent = createDefaultValuesJsonExport({});
-    const expectedPercentagesJsonContent = createDefaultPercentagesJsonExport({});
+    const expectedAnnualJsonContent = createDefaultJsonExport();
 
-    expect(jsonParse.values).toEqual(expectedAnnualValuesJsonContent.values);
-    expect(jsonParse.percentages).toEqual(expectedPercentagesJsonContent.percentages);
+    expect(jsonParse).toEqual(expectedAnnualJsonContent);
   });
 
   test('T20 Export and read JSON (Monthly)', async ({ page, estimationsSection }) => {
@@ -49,23 +42,17 @@ test.describe('Download and read files', () => {
     const downloadPath = await estimationsSection.downloadFile(page, 'Export JSON');
     const jsonParse = await estimationsSection.readJsonFileContent(downloadPath);
 
-    const expectedPercentagesJsonContent = createDefaultPercentagesJsonExport({});
-
-    expect(jsonParse.values).toEqual(TestData.t20ExpectedMonthlyValuesJson.values);
-    expect(jsonParse.percentages).toEqual(expectedPercentagesJsonContent.percentages);
+    expect(jsonParse).toEqual(TestData.t20ExpectedMonthlyJson);
   });
 
   test('T20 Export and read JSON with inputs (Annual)', async ({ page, estimationsSection }) => {
     const downloadPath = await estimationsSection.downloadFile(page, 'Export JSON with Inputs');
     const jsonParse = await estimationsSection.readJsonFileContent(downloadPath);
 
-    const expectedValuesJsonContent = createDefaultValuesJsonExport({});
-    const expectedPercentagesJsonContent = createDefaultPercentagesJsonExport({});
-    const expectedInputsJsonContent = createDefaultInputJsonExport({});
+    const expectedJsonContent = createDefaultJsonExport();
+    const expectedInputsJsonContent = createDefaultInputJsonExport(expectedJsonContent);
 
-    expect(jsonParse.estimate.values).toEqual(expectedValuesJsonContent.values);
-    expect(jsonParse.estimate.percentages).toEqual(expectedPercentagesJsonContent.percentages);
-    expect(jsonParse.input).toEqual(expectedInputsJsonContent.input);
+    expect(jsonParse).toEqual(expectedInputsJsonContent);
   });
 
   test('T20 Export and read JSON with inputs (Monthly)', async ({ page, estimationsSection }) => {
@@ -73,12 +60,9 @@ test.describe('Download and read files', () => {
     const downloadPath = await estimationsSection.downloadFile(page, 'Export JSON with Inputs');
     const jsonParse = await estimationsSection.readJsonFileContent(downloadPath);
 
-    const expectedPercentagesJsonContent = createDefaultPercentagesJsonExport({});
-    const expectedInputsJsonContent = createDefaultInputJsonExport({});
+    const expectedInputsJsonContent = createDefaultInputJsonExport(TestData.t20ExpectedMonthlyJson);
 
-    expect(jsonParse.estimate.values).toEqual(TestData.t20ExpectedMonthlyValuesJson.values);
-    expect(jsonParse.estimate.percentages).toEqual(expectedPercentagesJsonContent.percentages);
-    expect(jsonParse.input).toEqual(expectedInputsJsonContent.input);
+    expect(jsonParse).toEqual(expectedInputsJsonContent);
     console.log(downloadPath);
   });
 

--- a/playwright-tests/utilities/test-data.ts
+++ b/playwright-tests/utilities/test-data.ts
@@ -1,3 +1,5 @@
+import { CarbonSchemaExtended } from '../../src/app/types/tech-carbon-standard.schema';
+
 export const t2ExpectedEmissionPercentages = [
   '34%',
   '25%',
@@ -991,33 +993,90 @@ export const t18ExpectedMonthlyEmissionKilogramsNoExternalUsersArray = [
   ' 4585 kg ',
 ];
 
-export const t20ExpectedMonthlyValuesJson = {
-  values: {
-    version: '0.0.0-semantically-released',
-    upstreamEmissions: {
-      employee: 1142.361111111111,
-      server: 302.0833333333333,
-      network: 108.33333333333333,
-      software: 0,
-      foundationModels: 0,
-      contentAndData: 0,
+export const t20ExpectedMonthlyJson: CarbonSchemaExtended = {
+  schema_version: '0.1.0',
+  upstream_emissions: {
+    software: {
+      emissions: 0,
+      percentage: 0,
     },
-    directEmissions: {
-      employee: 540.3807833333334,
-      server: 2182.46348,
-      network: 257.77241919,
+    employee_hardware: {
+      emissions: 1142.361111111111,
+      percentage: 24.740601273220566,
     },
-    indirectEmissions: {
-      cloud: 51.739522,
-      saas: 0,
-      managed: 0,
+    network_hardware: {
+      emissions: 108.33333333333333,
+      percentage: 2.346221154177756,
     },
-    downstreamEmissions: {
-      customer: 12.300793980596879,
-      networkTransfer: 19.91909679336675,
-      downstreamInfrastructure: 0,
+    server_hardware: {
+      emissions: 302.0833333333333,
+      percentage: 6.542347449149511,
     },
-    totalEmissions: 4617.353873075075,
+    foundation_models: {
+      emissions: 0,
+      percentage: 0,
+      notes: 'Calculation not currently implemented',
+    },
+    content_and_data: {
+      emissions: 0,
+      percentage: 0,
+      notes: 'Calculation not currently implemented',
+    },
+  },
+  direct_emissions: {
+    onsite_employee_hardware: {
+      emissions: 540.3807833333334,
+      percentage: 11.70325684770289,
+    },
+    networking: {
+      emissions: 257.77241919,
+      percentage: 5.582687103389114,
+    },
+    servers: {
+      emissions: 2182.46348,
+      percentage: 47.26654139996678,
+    },
+    generators: {
+      emissions: 0,
+      percentage: 0,
+      notes: 'Calculation not currently implemented',
+    },
+  },
+  indirect_emissions: {
+    offsite_employee_hardware: {
+      emissions: 0,
+      percentage: 0,
+      notes: 'Calculation not currently implemented',
+    },
+    cloud_services: {
+      emissions: 51.739522,
+      percentage: 1.1205448709856498,
+    },
+    saas: {
+      emissions: 0,
+      percentage: 0,
+    },
+    managed_services: {
+      emissions: 0,
+      percentage: 0,
+    },
+  },
+  downstream_emissions: {
+    customer_devices: {
+      emissions: 12.300793980596879,
+      percentage: 0.2664035358503889,
+    },
+    network_data_transfer: {
+      emissions: 19.91909679336675,
+      percentage: 0.4313963655573357,
+    },
+    downstream_infrastructure: {
+      emissions: 0,
+      percentage: 0,
+    },
+  },
+  total_emissions: {
+    value: 4617.353873075075,
   },
 };
 

--- a/playwright-tests/utilities/test-helpers.ts
+++ b/playwright-tests/utilities/test-helpers.ts
@@ -1,120 +1,143 @@
 import AxeBuilder from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
-import { EmissionInputsSchema, EmissionPercentagesSchema, EmissionValuesSchema } from './types';
 import { pdfToPng } from 'pdf-to-png-converter';
+import { CarbonSchemaExtended } from '../../src/app/types/tech-carbon-standard.schema';
 
 export const expectNoA11yViolations = async (page: Page) => {
   const results = await new AxeBuilder({ page }).analyze();
   expect(results.violations).toEqual([]);
 };
 
-export function createDefaultValuesJsonExport(overrides: Partial<EmissionValuesSchema> = {}): EmissionValuesSchema {
-  const defaultValuesJson = {
-    values: {
-      version: '0.0.0-semantically-released',
-      upstreamEmissions: {
-        employee: 13708.333333333334,
-        server: 3625,
-        network: 1300,
-        software: 0,
-        foundationModels: 0,
-        contentAndData: 0,
+export function createDefaultJsonExport(): CarbonSchemaExtended {
+  const defaultJson: CarbonSchemaExtended = {
+    schema_version: '0.1.0',
+    upstream_emissions: {
+      software: {
+        emissions: 0,
+        percentage: 0,
       },
-      directEmissions: {
-        employee: 6484.5694,
-        server: 26189.56176,
-        network: 3093.2690302799997,
+      employee_hardware: {
+        emissions: 13708.333333333334,
+        percentage: 24.740601273220566,
       },
-      indirectEmissions: {
-        cloud: 620.874264,
-        saas: 0,
-        managed: 0,
+      network_hardware: {
+        emissions: 1300,
+        percentage: 2.346221154177756,
       },
-      downstreamEmissions: {
-        customer: 147.60952776716255,
-        networkTransfer: 239.029161520401,
-        downstreamInfrastructure: 0,
+      server_hardware: {
+        emissions: 3625,
+        percentage: 6.542347449149511,
       },
-      totalEmissions: 55408.2464769009,
+      foundation_models: {
+        emissions: 0,
+        percentage: 0,
+        notes: 'Calculation not currently implemented',
+      },
+      content_and_data: {
+        emissions: 0,
+        percentage: 0,
+        notes: 'Calculation not currently implemented',
+      },
+    },
+    direct_emissions: {
+      onsite_employee_hardware: {
+        emissions: 6484.5694,
+        percentage: 11.70325684770289,
+      },
+      networking: {
+        emissions: 3093.2690302799997,
+        percentage: 5.582687103389114,
+      },
+      servers: {
+        emissions: 26189.56176,
+        percentage: 47.26654139996678,
+      },
+      generators: {
+        emissions: 0,
+        percentage: 0,
+        notes: 'Calculation not currently implemented',
+      },
+    },
+    indirect_emissions: {
+      offsite_employee_hardware: {
+        emissions: 0,
+        percentage: 0,
+        notes: 'Calculation not currently implemented',
+      },
+      cloud_services: {
+        emissions: 620.874264,
+        percentage: 1.1205448709856498,
+      },
+      saas: {
+        emissions: 0,
+        percentage: 0,
+      },
+      managed_services: {
+        emissions: 0,
+        percentage: 0,
+      },
+    },
+    downstream_emissions: {
+      customer_devices: {
+        emissions: 147.60952776716255,
+        percentage: 0.2664035358503889,
+      },
+      network_data_transfer: {
+        emissions: 239.029161520401,
+        percentage: 0.4313963655573357,
+      },
+      downstream_infrastructure: {
+        emissions: 0,
+        percentage: 0,
+      },
+    },
+    total_emissions: {
+      value: 55408.2464769009,
     },
   };
-  return { ...defaultValuesJson, ...overrides };
+  return defaultJson;
 }
 
-export function createDefaultPercentagesJsonExport(
-  overrides: Partial<EmissionPercentagesSchema> = {}
-): EmissionPercentagesSchema {
-  const defaultPercentagesJson = {
-    percentages: {
-      version: '0.0.0-semantically-released',
-      upstreamEmissions: {
-        employee: 24.740601273220566,
-        server: 6.542347449149511,
-        network: 2.346221154177756,
-        software: 0,
-        foundationModels: 0,
-        contentAndData: 0,
-      },
-      directEmissions: {
-        employee: 11.70325684770289,
-        server: 47.26654139996678,
-        network: 5.582687103389114,
-      },
-      indirectEmissions: {
-        cloud: 1.1205448709856498,
-        saas: 0,
-        managed: 0,
-      },
-      downstreamEmissions: {
-        customer: 0.2664035358503889,
-        networkTransfer: 0.4313963655573357,
-        downstreamInfrastructure: 0,
-      },
-      totalEmissions: 55408.2464769009,
-    },
-  };
-  return { ...defaultPercentagesJson, ...overrides };
-}
-
-export function createDefaultInputJsonExport(overrides: Partial<EmissionInputsSchema> = {}): EmissionInputsSchema {
-  const defaultInputJson = {
+export function createDefaultInputJsonExport(estimate: CarbonSchemaExtended): CarbonSchemaExtended {
+  const defaultInputJson: CarbonSchemaExtended = {
+    ...estimate,
     input: {
-      upstream: {
-        headCount: 100,
-        desktopPercentage: 50,
-        employeeLocation: 'WORLD',
+      upstream_emissions: {
+        head_count: 100,
+        desktop_percentage: 50,
+        employee_location: 'WORLD',
       },
-      onPremise: {
-        estimateServerCount: false,
-        serverLocation: 'WORLD',
-        numberOfServers: 10,
+      on_premises: {
+        estimate_server_count: false,
+        server_location: 'WORLD',
+        number_of_servers: 10,
       },
       cloud: {
-        noCloudServices: false,
-        cloudLocation: 'WORLD',
-        cloudPercentage: 50,
-        monthlyCloudBill: {
+        no_cloud_services: false,
+        cloud_location: 'WORLD',
+        cloud_percentage: 50,
+        monthly_cloud_bill: {
           min: 0,
           max: 1000,
         },
       },
-      downstream: {
-        noDownstream: false,
-        customerLocation: 'WORLD',
-        monthlyActiveUsers: 100,
-        mobilePercentage: 50,
-        purposeOfSite: 'average',
+      downstream_emissions: {
+        no_downstream: false,
+        customer_location: 'WORLD',
+        monthly_active_users: 100,
+        mobile_percentage: 50,
+        purpose_of_site: 'average',
       },
       saas: {
         microsoft365: {
-          useMicrosoft365: false,
-          organisationUserCount: 100,
+          use_microsoft365: false,
+          organisation_user_count: 100,
         },
       },
     },
   };
-  return { ...defaultInputJson, ...overrides };
+  return defaultInputJson;
 }
 
 export async function pdfComparison(actual_pdf_path: string, expected_pdf_path: string) {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -16,7 +16,7 @@ import { ExpansionPanelComponent } from '../expansion-panel/expansion-panel.comp
 import { TabsComponent } from '../tab/tabs/tabs.component';
 import { TabItemComponent } from '../tab/tab-item/tab-item.component';
 import { CarbonEstimationTreemapComponent } from '../carbon-estimation-treemap/carbon-estimation-treemap.component';
-import { CarbonEstimation, EstimatorValues, jsonExport } from '../types/carbon-estimator';
+import { CarbonEstimation, EstimatorValues, JsonExport } from '../types/carbon-estimator';
 import { sumValues } from '../utils/number-object';
 import { estimatorHeights } from './carbon-estimation.constants';
 import { debounceTime, fromEvent, Subscription } from 'rxjs';
@@ -136,13 +136,12 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
     return this.getJSONExportUrl(exportObject);
   }
 
-  private getJSONExportUrl(exportObject: jsonExport): string {
+  private getJSONExportUrl(exportObject: JsonExport): string {
     const mappedJson = this.carbonSchemaMapper.mapEstimationToSchema(exportObject);
 
     const estimateJson = JSON.stringify(mappedJson, null, 2);
     const blob = new Blob([estimateJson], { type: 'application/json' });
-    const carbonEstimationJSONUrl = URL.createObjectURL(blob);
-    return carbonEstimationJSONUrl;
+    return URL.createObjectURL(blob);
   }
 
   public showModal() {

--- a/src/app/carbon-estimation/carbon-estimation.component.ts
+++ b/src/app/carbon-estimation/carbon-estimation.component.ts
@@ -23,6 +23,7 @@ import { debounceTime, fromEvent, Subscription } from 'rxjs';
 import { CarbonEstimationTableComponent } from '../carbon-estimation-table/carbon-estimation-table.component';
 import { ExternalLinkDirective } from '../directives/external-link.directive';
 import { CommonModule } from '@angular/common';
+import { CarbonSchemaMapperService } from '../services/carbon-schema-mapper.service';
 
 @Component({
   selector: 'carbon-estimation',
@@ -46,6 +47,7 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   public isAnnual = signal(true);
   public isModalVisible = false;
   public chartHeight!: number;
+  private carbonSchemaMapper = inject(CarbonSchemaMapperService);
 
   public diagramActive = signal(true);
 
@@ -125,7 +127,7 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
   }
 
   get carbonEstimationDownloadUrl(): string {
-    const exportObject = this.estimate();
+    const exportObject = { estimate: this.estimate(), input: undefined };
     return this.getJSONExportUrl(exportObject);
   }
 
@@ -134,12 +136,10 @@ export class CarbonEstimationComponent implements OnInit, OnDestroy {
     return this.getJSONExportUrl(exportObject);
   }
 
-  private getJSONExportUrl(exportObject: CarbonEstimation | jsonExport | undefined): string {
-    if (typeof exportObject === 'undefined') {
-      return '';
-    }
+  private getJSONExportUrl(exportObject: jsonExport): string {
+    const mappedJson = this.carbonSchemaMapper.mapEstimationToSchema(exportObject);
 
-    const estimateJson = JSON.stringify(exportObject, null, 2);
+    const estimateJson = JSON.stringify(mappedJson, null, 2);
     const blob = new Blob([estimateJson], { type: 'application/json' });
     const carbonEstimationJSONUrl = URL.createObjectURL(blob);
     return carbonEstimationJSONUrl;

--- a/src/app/services/carbon-schema-mapper.service.ts
+++ b/src/app/services/carbon-schema-mapper.service.ts
@@ -1,0 +1,143 @@
+import { Injectable } from '@angular/core';
+import { jsonExport } from '../types/carbon-estimator';
+import { CarbonSchemaExtended } from '../types/tech-carbon-standard.schema';
+
+@Injectable({ providedIn: 'root' })
+export class CarbonSchemaMapperService {
+  private readonly SCHEMA_VERSION = '0.1.0';
+
+  mapEstimationToSchema(jsonExport: jsonExport): CarbonSchemaExtended {
+    const estimation = jsonExport.estimate;
+    const input = jsonExport.input;
+
+    if (!estimation) {
+      throw new Error('Carbon estimation object is undefined');
+    }
+
+    const values = estimation.values;
+    const percentages = estimation.percentages;
+
+    return {
+      schema_version: this.SCHEMA_VERSION,
+      upstream_emissions: {
+        software: {
+          emissions: values.upstreamEmissions.software,
+          percentage: percentages.upstreamEmissions.software,
+        },
+        employee_hardware: {
+          emissions: values.upstreamEmissions.employee,
+          percentage: percentages.upstreamEmissions.employee,
+        },
+        network_hardware: {
+          emissions: values.upstreamEmissions.network,
+          percentage: percentages.upstreamEmissions.network,
+        },
+        server_hardware: {
+          emissions: values.upstreamEmissions.server,
+          percentage: percentages.upstreamEmissions.server,
+        },
+        foundation_models: {
+          emissions: values.upstreamEmissions.foundationModels,
+          percentage: percentages.upstreamEmissions.foundationModels,
+          notes: 'Calculation not currently implemented',
+        },
+        content_and_data: {
+          emissions: values.upstreamEmissions.contentAndData,
+          percentage: percentages.upstreamEmissions.contentAndData,
+          notes: 'Calculation not currently implemented',
+        },
+      },
+      direct_emissions: {
+        onsite_employee_hardware: {
+          emissions: values.directEmissions.employee,
+          percentage: percentages.directEmissions.employee,
+        },
+        networking: {
+          emissions: values.directEmissions.network,
+          percentage: percentages.directEmissions.network,
+        },
+        servers: {
+          emissions: values.directEmissions.server,
+          percentage: percentages.directEmissions.server,
+        },
+        generators: {
+          emissions: 0,
+          percentage: 0,
+          notes: 'Calculation not currently implemented',
+        },
+      },
+      indirect_emissions: {
+        offsite_employee_hardware: {
+          emissions: 0,
+          percentage: 0,
+          notes: 'Calculation not currently implemented',
+        },
+        cloud_services: {
+          emissions: values.indirectEmissions.cloud,
+          percentage: percentages.indirectEmissions.cloud,
+        },
+        saas: {
+          emissions: values.indirectEmissions.saas,
+          percentage: percentages.indirectEmissions.saas,
+        },
+        managed_services: {
+          emissions: values.indirectEmissions.managed,
+          percentage: percentages.indirectEmissions.managed,
+        },
+      },
+      downstream_emissions: {
+        customer_devices: {
+          emissions: values.downstreamEmissions.customer,
+          percentage: percentages.downstreamEmissions.customer,
+        },
+        network_data_transfer: {
+          emissions: values.downstreamEmissions.networkTransfer,
+          percentage: percentages.downstreamEmissions.networkTransfer,
+        },
+        downstream_infrastructure: {
+          emissions: values.downstreamEmissions.downstreamInfrastructure,
+          percentage: percentages.downstreamEmissions.downstreamInfrastructure,
+        },
+      },
+      total_emissions: {
+        value: values.totalEmissions,
+      },
+      ...(input && {
+        input: {
+          upstream_emissions: {
+            head_count: input.upstream.headCount,
+            desktop_percentage: input.upstream.desktopPercentage,
+            employee_location: input.upstream.employeeLocation,
+          },
+          on_premises: {
+            estimate_server_count: input.onPremise.estimateServerCount,
+            server_location: input.onPremise.serverLocation,
+            number_of_servers: input.onPremise.numberOfServers,
+          },
+          cloud: {
+            no_cloud_services: input.cloud.noCloudServices,
+            cloud_location: input.cloud.cloudLocation,
+            cloud_percentage: input.cloud.cloudPercentage,
+            monthly_cloud_bill: {
+              min: input.cloud.monthlyCloudBill.min,
+              max: input.cloud.monthlyCloudBill.max,
+            },
+          },
+          downstream_emissions: {
+            no_downstream: input.downstream.noDownstream,
+            customer_location: input.downstream.customerLocation,
+            monthly_active_users: input.downstream.monthlyActiveUsers,
+            mobile_percentage: input.downstream.mobilePercentage,
+            purpose_of_site: input.downstream.purposeOfSite,
+          },
+          saas: {
+            microsoft365: {
+              use_microsoft365: input.saas.microsoft365.useMicrosoft365,
+              organisation_user_count: input.saas.microsoft365.organisationUserCount,
+            },
+          },
+        },
+      }),
+    };
+  }
+}

--- a/src/app/services/carbon-schema-mapper.service.ts
+++ b/src/app/services/carbon-schema-mapper.service.ts
@@ -1,21 +1,19 @@
 import { Injectable } from '@angular/core';
-import { jsonExport } from '../types/carbon-estimator';
+import { JsonExport } from '../types/carbon-estimator';
 import { CarbonSchemaExtended } from '../types/tech-carbon-standard.schema';
 
 @Injectable({ providedIn: 'root' })
 export class CarbonSchemaMapperService {
   private readonly SCHEMA_VERSION = '0.1.0';
 
-  mapEstimationToSchema(jsonExport: jsonExport): CarbonSchemaExtended {
-    const estimation = jsonExport.estimate;
-    const input = jsonExport.input;
+  mapEstimationToSchema(jsonExport: JsonExport): CarbonSchemaExtended {
+    const { estimate, input } = jsonExport;
 
-    if (!estimation) {
+    if (!estimate) {
       throw new Error('Carbon estimation object is undefined');
     }
 
-    const values = estimation.values;
-    const percentages = estimation.percentages;
+    const { values, percentages } = estimate;
 
     return {
       schema_version: this.SCHEMA_VERSION,

--- a/src/app/types/carbon-estimator.ts
+++ b/src/app/types/carbon-estimator.ts
@@ -127,7 +127,7 @@ export type ChartOptions = {
   dataLabels: ApexDataLabels;
 };
 
-export type jsonExport = {
+export type JsonExport = {
   estimate: CarbonEstimation | undefined;
   input: EstimatorValues | undefined;
 };

--- a/src/app/types/tech-carbon-standard.schema.ts
+++ b/src/app/types/tech-carbon-standard.schema.ts
@@ -1,0 +1,72 @@
+export interface Emission {
+  emissions: number;
+  percentage: number;
+  notes?: string;
+  method?: string;
+}
+
+export interface CarbonSchemaExtended {
+  schema_version: string;
+  upstream_emissions: {
+    software: Emission;
+    employee_hardware: Emission;
+    network_hardware: Emission;
+    server_hardware: Emission;
+    foundation_models: Emission;
+    content_and_data: Emission;
+  };
+  direct_emissions: {
+    onsite_employee_hardware: Emission;
+    networking: Emission;
+    servers: Emission;
+    generators: Emission;
+  };
+  indirect_emissions: {
+    offsite_employee_hardware: Emission;
+    cloud_services: Emission;
+    saas: Emission;
+    managed_services: Emission;
+  };
+  downstream_emissions: {
+    customer_devices: Emission;
+    network_data_transfer: Emission;
+    downstream_infrastructure: Emission;
+  };
+  total_emissions: {
+    value: number;
+  };
+  input?: {
+    upstream_emissions: {
+      head_count: number;
+      desktop_percentage: number;
+      employee_location: string;
+    };
+    on_premises: {
+      estimate_server_count: boolean;
+      server_location: string;
+      number_of_servers: number;
+    };
+    cloud: {
+      no_cloud_services: boolean;
+      cloud_location: string;
+      cloud_percentage: number;
+      monthly_cloud_bill: {
+        min: number;
+        max: number;
+      };
+    };
+    downstream_emissions: {
+      no_downstream: boolean;
+      customer_location: string;
+      monthly_active_users: number;
+      mobile_percentage: number;
+      purpose_of_site: string;
+    };
+    saas: {
+      microsoft365: {
+        use_microsoft365: boolean;
+        organisation_user_count: number;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Resolves #309

**Marked as breaking change due to change in exported JSON structure**

## Description of Change

Modifies the structure of Carbon Estimation and calculation input value objects before exporting to JSON:
- Uses a mapper service to map TCE object values to an extended version of the TCS schema
  - 'Extended' because of the presence of values in this schema that are not in the TCS schema:
    - Percentages alongside emissions values
    - Total emissions value
    - Calculation input values
- Adds TCS schema objects as types
- Simplifies the data types passed to the JSON export method to only the `jsonExport` type
- Updated four Playwright tests (T20) to correct for the new schema

### Examples:

Before:
[carbon-estimation-before.json](https://github.com/user-attachments/files/24433685/carbon-estimation-before.json)

After:
[carbon-estimation-after.json](https://github.com/user-attachments/files/24433689/carbon-estimation-after.json)

Before with inputs:
[carbon-estimation-with-inputs-before.json](https://github.com/user-attachments/files/24433694/carbon-estimation-with-inputs-before.json)

After with inputs:
[carbon-estimation-with-inputs-after.json](https://github.com/user-attachments/files/24433699/carbon-estimation-with-inputs-after.json)