### PR TITLE
333: Disable chart animations in PDF export modal

### DIFF
--- a/playwright-tests/page-objects/estimations-section.ts
+++ b/playwright-tests/page-objects/estimations-section.ts
@@ -1,7 +1,6 @@
 import type { Page, Locator } from '@playwright/test';
 import { expect } from '@playwright/test';
 import * as fs from 'fs';
-import { customWait } from '../utilities/test-helpers';
 
 export class EstimationsSection {
   public readonly diagramViewButton: Locator;
@@ -49,7 +48,6 @@ export class EstimationsSection {
     await exportListOption.click();
 
     if (exportType === 'Export PDF') {
-      await customWait(3); // Wait for apex charts to render before clicking download
       await this.pdfTitle.fill('Test PDF Export');
       await this.downloadPdfButton.click();
     }

--- a/playwright-tests/utilities/test-helpers.ts
+++ b/playwright-tests/utilities/test-helpers.ts
@@ -148,7 +148,3 @@ export async function pdfComparison(actual_pdf_path: string, expected_pdf_path: 
     expect.soft(convertedPdf[i].content).toMatchSnapshot(expectedPdf[i]);
   }
 }
-
-export async function customWait(seconds: number) {
-  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
-}

--- a/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.ts
+++ b/src/app/carbon-estimation-treemap/carbon-estimation-treemap.component.ts
@@ -33,6 +33,7 @@ export class CarbonEstimationTreemapComponent {
   public carbonEstimation = input<CarbonEstimation>();
   public chartHeight = input.required<number>();
   public shouldShowUnitsSwitch = input.required<boolean>();
+  public enableAnimations = input<boolean>(true);
 
   public chartData = computed(() => this.getChartData(this.carbonEstimation()));
   public emissionAriaLabel = computed(() => this.getAriaLabel(this.chartData(), !this.carbonEstimation()));
@@ -59,12 +60,13 @@ export class CarbonEstimationTreemapComponent {
 
   public toggleMassPercentages = () => {
     this.isMass.update(value => !value);
-    // this.getChartData(this.carbonEstimation());
   };
 
   private getChartOptions(isPlaceholder: boolean) {
     const chartOptions = getBaseChartOptions(isPlaceholder, this.isMass());
     chartOptions.chart.height = this.chartHeight();
+    chartOptions.chart.animations ??= {};
+    chartOptions.chart.animations.enabled = this.enableAnimations();
     return chartOptions;
   }
 

--- a/src/app/export-modal/export-modal.component.html
+++ b/src/app/export-modal/export-modal.component.html
@@ -18,6 +18,7 @@
           [carbonEstimation]="carbonEstimation()"
           [chartHeight]="chartHeight"
           [shouldShowUnitsSwitch]="false"
+          [enableAnimations]="false"
           class="tce:!pointer-events-none"></carbon-estimation-treemap>
         <carbon-estimation-table
           [carbonEstimation]="carbonEstimation()"


### PR DESCRIPTION
Resolves #333

Adds property to enable/disable animations of the tree chart (enabled by default), and uses the property to disable animations in the PDF export modal.

![disable-animations-pdf-export-modal](https://github.com/user-attachments/assets/05b0a4c3-0f6c-4901-bb17-413c9f7f5746)
