### PR TITLE
337: Hide Cloud/On-Premise question unless required

### DIFF
--- a/playwright-tests/e2e/T11-calculation-1M-desktop-users-800K-end-users.spec.ts
+++ b/playwright-tests/e2e/T11-calculation-1M-desktop-users-800K-end-users.spec.ts
@@ -15,19 +15,13 @@ test('T11 verify calculated values are coherent with selected employees, servers
 }) => {
   await tcsEstimator.gotoHome();
   await allSections.assertAllSectionElementsAreVisible();
-
   await organisationSection.selectNumberOfEmployess('1000000');
   await organisationSection.percentageSlider.click();
   await organisationSection.percentageSliderSet('100');
   await expect(organisationSection.percentageSliderText).toHaveValue('100');
-
   await onPremSection.selectNumberOfServers('100');
   await onPremSection.selectLocationOfServers('unknown');
-  await cloudServicesSection.percentageSlider.click();
-  await cloudServicesSection.percentageSliderSet('15');
-  await expect(cloudServicesSection.percentageSlider).toHaveValue('15');
   await cloudServicesSection.setMonthlyCloudBill('4: Object');
-
   await customersSection.setCustomersLocation('Globally');
   await page.getByLabel('How many monthly active users').click();
   await customersSection.setMonthlyActiveUsers('800000');
@@ -35,7 +29,6 @@ test('T11 verify calculated values are coherent with selected employees, servers
   await customersSection.percentageSliderSet('15');
   await expect(customersSection.percentageSlider).toHaveValue('15');
   await customersSection.setPrimaryPurpose('socialMedia');
-
   await tcsEstimator.calculateButton.click();
   await diagramSection.assertDiagramScreenshot('T11-apex-chart-kilograms-annual.png');
   await estimationsSection.monthlyViewButton.click();
@@ -44,7 +37,6 @@ test('T11 verify calculated values are coherent with selected employees, servers
   await diagramSection.assertDiagramScreenshot('T11-apex-chart-percentages.png');
   await estimationsSection.tableViewButton.click();
   await tableSection.assertPopulatedTableStructure();
-
   await tableSection.assertCorrectKilogramColumnValues(TestData.t11ExpectedEmissionKilogramsMonthly);
   await estimationsSection.annualViewButton.click();
   await tableSection.assertCorrectKilogramColumnValues(TestData.t11ExpectedEmissionKilogramsAnnual);

--- a/playwright-tests/e2e/T14-calculation-25k-employees-500-servers-1M-users.spec.ts
+++ b/playwright-tests/e2e/T14-calculation-25k-employees-500-servers-1M-users.spec.ts
@@ -23,8 +23,6 @@ test('T14 verify calculated values are coherent with selected employees, servers
   await onPremSection.selectNumberOfServers('500');
   await expect(onPremSection.locationOfServersField).toHaveValue('WORLD');
 
-  await cloudServicesSection.percentageSliderSet('45');
-  await expect(cloudServicesSection.percentageSlider).toHaveValue('45');
   await cloudServicesSection.setCloudLocation('GBR');
   await cloudServicesSection.setCloudLocation('WORLD');
   await expect(cloudServicesSection.monthlyCloudBill).toHaveValue('0: Object');

--- a/playwright-tests/e2e/T15-calculation-6k-employees-479-servers-650k-users.spec.ts
+++ b/playwright-tests/e2e/T15-calculation-6k-employees-479-servers-650k-users.spec.ts
@@ -23,11 +23,6 @@ test('T15 verify calculated values are coherent with selected employees, servers
   await onPremSection.selectNumberOfServers('479');
   await onPremSection.selectLocationOfServers('Globally');
 
-  await cloudServicesSection.percentageSlider.click();
-  await cloudServicesSection.percentageSliderSet('45');
-  await cloudServicesSection.percentageSliderSet('50');
-  await cloudServicesSection.percentageSliderSet('80');
-  await expect(cloudServicesSection.percentageSlider).toHaveValue('80');
   await expect(cloudServicesSection.serverLocation).toHaveValue('WORLD');
   await cloudServicesSection.setMonthlyCloudBill('7: Object');
 

--- a/playwright-tests/e2e/T17-calculation-80%-cloud-usage.spec.ts
+++ b/playwright-tests/e2e/T17-calculation-80%-cloud-usage.spec.ts
@@ -21,7 +21,6 @@ test('T17 calculations show 80% cloud usage', async ({
   await onPremSection.selectNumberOfServers('10');
   await onPremSection.selectLocationOfServers('WORLD');
 
-  await page.getByText('On-premise 50%').click();
   await cloudServicesSection.setCloudLocation('in the UK');
   await cloudServicesSection.setMonthlyCloudBill('10: Object');
 

--- a/playwright-tests/e2e/T2-calculation-happy-path.spec.ts
+++ b/playwright-tests/e2e/T2-calculation-happy-path.spec.ts
@@ -10,7 +10,6 @@ const input_values = {
   number_of_servers: '10',
   server_location: 'Globally',
   no_cloud: false,
-  cloud_percentage: '50',
   cloud_location: 'WORLD',
   monthly_cloud_cost: '0: Object',
   uses_m365: true,

--- a/playwright-tests/e2e/T3-calculation-with-reset.spec.ts
+++ b/playwright-tests/e2e/T3-calculation-with-reset.spec.ts
@@ -5,7 +5,7 @@ const input_values = {
   employees: '100',
   hardware_percentage: '75',
   employees_location: 'in the UK',
-  unknown_servers: false,
+  unknown_servers: true,
   number_of_servers: '10',
   server_location: 'in the UK',
   no_cloud: false,

--- a/playwright-tests/e2e/T4-calculation-desktop-zero.spec.ts
+++ b/playwright-tests/e2e/T4-calculation-desktop-zero.spec.ts
@@ -21,9 +21,6 @@ test('T4 verify calculated values are coherent when desktop is 0%', async ({
   await onPremSection.selectLocationOfServers('GBR');
   await onPremSection.selectLocationOfServers('Globally');
 
-  await cloudServicesSection.percentageSlider.click();
-  await cloudServicesSection.percentageSliderSet('45');
-  await expect(cloudServicesSection.percentageSlider).toHaveValue('45');
   await cloudServicesSection.setCloudLocation('GBR');
   await cloudServicesSection.setCloudLocation('WORLD');
 

--- a/playwright-tests/e2e/T5-calculation-laptop-zero.spec.ts
+++ b/playwright-tests/e2e/T5-calculation-laptop-zero.spec.ts
@@ -21,9 +21,6 @@ test('T5 verify calculated values are coherent when laptop is 0%', async ({
   await onPremSection.selectLocationOfServers('GBR');
   await onPremSection.selectLocationOfServers('Globally');
 
-  await cloudServicesSection.percentageSlider.click();
-  await cloudServicesSection.percentageSliderSet('45');
-  await expect(cloudServicesSection.percentageSlider).toHaveValue('45');
   await cloudServicesSection.setCloudLocation('GBR');
   await cloudServicesSection.setCloudLocation('WORLD');
 

--- a/playwright-tests/e2e/T7-calculation-on-prem-is-known-then-it-is-unknown.spec.ts
+++ b/playwright-tests/e2e/T7-calculation-on-prem-is-known-then-it-is-unknown.spec.ts
@@ -47,7 +47,7 @@ test('T7 verify calculated values are coherent when on-prem is known then recalu
   await onPremSection.selectLocationOfServers('in the UK');
   await onPremSection.selectLocationOfServers('Globally');
 
-  await cloudServicesSection.assertDefaultCloudElementVisibility();
+  await cloudServicesSection.assertDefaultCloudElementVisibility(true);
 
   await customersSection.assertCustomersSectionVisible();
   await customersSection.setPrimaryPurpose('information');

--- a/playwright-tests/page-objects/all-sections.ts
+++ b/playwright-tests/page-objects/all-sections.ts
@@ -35,9 +35,9 @@ export class AllSections {
     );
     await this.cloudServicesSection.cloudInputs(
       input_values.no_cloud,
-      input_values.cloud_percentage,
       input_values.cloud_location,
-      input_values.monthly_cloud_cost
+      input_values.monthly_cloud_cost,
+      input_values.cloud_percentage
     );
     await this.saasSection.saasInputs(input_values.uses_m365, input_values.m365_users);
     await this.customersSection.customerInputs(

--- a/playwright-tests/page-objects/cloud-services-section.ts
+++ b/playwright-tests/page-objects/cloud-services-section.ts
@@ -50,18 +50,26 @@ export class CloudServicesSection {
       .getByLabel('Hide details');
   }
 
-  async assertDefaultCloudElementVisibility() {
+  async assertDefaultCloudElementVisibility(isEstimatingOnPremServers: boolean = false) {
     await expect(this.cloudServicesHeading).toBeVisible();
     await expect(this.cloudServicesSummary).toBeVisible();
-    await expect(this.defaultCloudPercentage).toBeVisible();
-    await expect(this.defaultOnPremisePercentage).toBeVisible();
     await expect(this.serverLocation).toHaveValue('WORLD');
     await expect(this.monthlyCloudBill).toHaveValue('0: Object');
     await expect(this.CloudServicesNotUsedText).toBeVisible();
     await expect(this.cloudUnusedTickbox).not.toBeChecked();
-    await expect(this.percentageSlider).toBeVisible();
-    await expect(this.percentageSplitQuestion).toBeVisible();
     await expect(this.derivedRoughEstimateText).toBeVisible();
+
+    if (isEstimatingOnPremServers) {
+      await expect(this.defaultCloudPercentage).toBeVisible();
+      await expect(this.defaultOnPremisePercentage).toBeVisible();
+      await expect(this.percentageSlider).toBeVisible();
+      await expect(this.percentageSplitQuestion).toBeVisible();
+    } else {
+      await expect(this.defaultCloudPercentage).toBeHidden();
+      await expect(this.defaultOnPremisePercentage).toBeHidden();
+      await expect(this.percentageSlider).toBeHidden();
+      await expect(this.percentageSplitQuestion).toBeHidden();
+    }
   }
 
   async setCloudLocation(text: string) {

--- a/playwright-tests/page-objects/cloud-services-section.ts
+++ b/playwright-tests/page-objects/cloud-services-section.ts
@@ -86,11 +86,13 @@ export class CloudServicesSection {
     await this.percentageSlider.fill(value);
   }
 
-  async cloudInputs(unknown: boolean, percentage: string, location: string, bill: string) {
+  async cloudInputs(unknown: boolean, location: string, bill: string, percentage?: string) {
     if (unknown == true) {
       await this.cloudUnusedTickbox.click();
     } else {
-      await this.percentageSliderSet(percentage);
+      if (percentage !== undefined) {
+        await this.percentageSliderSet(percentage);
+      }
       await this.setCloudLocation(location);
       await this.setMonthlyCloudBill(bill);
     }

--- a/playwright-tests/utilities/types.ts
+++ b/playwright-tests/utilities/types.ts
@@ -101,7 +101,7 @@ export interface InputValues {
   number_of_servers: string;
   server_location: string;
   no_cloud: boolean;
-  cloud_percentage: string;
+  cloud_percentage?: string;
   cloud_location: string;
   monthly_cloud_cost: string;
   uses_m365: boolean;

--- a/src/app/features/cloud/components/cloud-form-section.component.html
+++ b/src/app/features/cloud/components/cloud-form-section.component.html
@@ -13,25 +13,27 @@
       </div>
 
       @if (!noCloudServices()) {
-        <div class="tce:flex tce:flex-col tce:gap-2">
-          <label for="cloudPercentage" class="tce:text-sm"
-            >What percentage of your servers are cloud services vs on-premise?</label
-          >
-          <input
-            id="cloudPercentage"
-            class="tce:cursor-pointer tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed"
-            formControlName="cloudPercentage"
-            name="cloudPercentage"
-            type="range"
-            min="0"
-            max="100"
-            step="5"
-            [attr.aria-valuetext]="'Cloud ' + cloudPercentage + '%, On-premise' + onPremisePercentage + '%'" />
-          <div class="tce:flex tce:justify-between tce:text-sm">
-            <span>Cloud {{ cloudPercentage() }}%</span>
-            <span>On-premise {{ onPremisePercentage() }}%</span>
+        @if (isEstimatingServers()) {
+          <div class="tce:flex tce:flex-col tce:gap-2">
+            <label for="cloudPercentage" class="tce:text-sm"
+              >What percentage of your servers are cloud services vs on-premise?</label
+            >
+            <input
+              id="cloudPercentage"
+              class="tce:cursor-pointer tce:disabled:bg-gray-200 tce:disabled:text-slate-400 tce:disabled:cursor-not-allowed"
+              formControlName="cloudPercentage"
+              name="cloudPercentage"
+              type="range"
+              min="0"
+              max="100"
+              step="5"
+              [attr.aria-valuetext]="'Cloud ' + cloudPercentage + '%, On-premise' + onPremisePercentage + '%'" />
+            <div class="tce:flex tce:justify-between tce:text-sm">
+              <span>Cloud {{ cloudPercentage() }}%</span>
+              <span>On-premise {{ onPremisePercentage() }}%</span>
+            </div>
           </div>
-        </div>
+        }
 
         <location-input [locationContext]="formContext.cloud.location!" formControlName="cloudLocation" />
 

--- a/src/app/features/cloud/components/cloud-form-section.component.ts
+++ b/src/app/features/cloud/components/cloud-form-section.component.ts
@@ -26,6 +26,7 @@ export class CloudFormSectionComponent implements OnInit {
 
   public noCloudServices = signal(defaultValues.cloud.noCloudServices);
   public cloudPercentage = signal(defaultValues.cloud.cloudPercentage);
+  public isEstimatingServers = signal(false);
   public onPremisePercentage: Signal<number> = computed(() => 100 - this.cloudPercentage());
 
   public compareCostRanges = compareCostRanges;
@@ -45,5 +46,14 @@ export class CloudFormSectionComponent implements OnInit {
       ?.valueChanges.subscribe(noCloudServices => {
         this.noCloudServices.set(noCloudServices);
       });
+
+    this.estimatorForm()
+      .get('onPremise.estimateServerCount')
+      ?.valueChanges.subscribe(val => {
+        this.isEstimatingServers.set(val);
+      });
+
+    const isEstimatingServersInitial = this.estimatorForm().get('onPremise.estimateServerCount')?.value;
+    this.isEstimatingServers.set(!!isEstimatingServersInitial);
   }
 }

--- a/src/app/features/on-premise/components/on-premise-form-section.component.ts
+++ b/src/app/features/on-premise/components/on-premise-form-section.component.ts
@@ -41,15 +41,15 @@ export class OnPremiseFormSectionComponent implements OnInit {
   ngOnInit(): void {
     this.form = this.formService.estimatorForm;
 
-    this.form.get('onPremise.estimateServerCount')?.valueChanges.subscribe(estimateServerCount => {
-      this.estimateServerCount = estimateServerCount;
+    const estimateControl = this.form.get('onPremise.estimateServerCount');
+
+    this.estimateServerCount = !!estimateControl?.value;
+    this.toggleServerInput(this.estimateServerCount);
+
+    estimateControl?.valueChanges.subscribe(isChecked => {
+      this.estimateServerCount = isChecked;
       this.refreshPreviewServerCount();
-      const noServers = this.form.get('onPremise.numberOfServers');
-      if (this.estimateServerCount) {
-        noServers?.disable();
-      } else {
-        noServers?.enable();
-      }
+      this.toggleServerInput(isChecked);
     });
 
     this.form.get('cloud.cloudPercentage')?.valueChanges.subscribe(() => this.refreshPreviewServerCount());
@@ -78,6 +78,15 @@ export class OnPremiseFormSectionComponent implements OnInit {
   private refreshPreviewServerCount() {
     if (this.estimateServerCount) {
       this.previewServerCount = this.estimationService.estimateServerCount(this.form.getRawValue() as EstimatorValues);
+    }
+  }
+
+  private toggleServerInput(isEstimating: boolean) {
+    const noServers = this.form.get('onPremise.numberOfServers');
+    if (isEstimating) {
+      noServers?.disable();
+    } else {
+      noServers?.enable();
     }
   }
 }


### PR DESCRIPTION
Resolves #337 

## Description of Change

- Hides the existing 'What percentage of your servers are cloud services vs on-premise?' question and associated slider unless the 'I don't know' checkbox in the On Premise section is checked
- Sets this state internally on load to ensure the elements are hidden (and the on-premise "we'll make an assumption" message is shown) if the checkbox loads pre-checked

![hide-question](https://github.com/user-attachments/assets/843d5dc4-b677-4e16-a3b0-230d14dd5164)
